### PR TITLE
feat: legacy format support, `--convert`, `--jobs`, and enhanced PDF/Office cleaning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           from docx import Document
           from pptx import Presentation
           from pypdf import PdfWriter, PdfReader
-          from pypdf.generic import RectangleObject, DictionaryObject, NameObject
+          from pypdf.generic import RectangleObject, DictionaryObject, NameObject, ArrayObject
 
           NS_XLSX = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
           NS_DOCX = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
@@ -66,7 +66,6 @@ jobs:
               os.replace(tmp, path)
 
           # ---------- OpenXML protected files ----------
-          # xlsx: workbook + sheet protection
           wb = Workbook()
           ws = wb.active
           ws["A1"] = "protected"
@@ -77,7 +76,6 @@ jobs:
               el.set("lockStructure", "1")
           inject_zip_xml("test_protected.xlsx", "workbook.xml", add_wb_protection)
 
-          # xlsx: open (no protection)
           wb2 = Workbook()
           wb2.active["A1"] = "open"
           wb2.save("test_open.xlsx")
@@ -86,7 +84,6 @@ jobs:
                   root.remove(el)
           inject_zip_xml("test_open.xlsx", "workbook.xml", remove_wb_protection)
 
-          # docx: documentProtection
           doc = Document()
           doc.add_paragraph("protected")
           doc.save("test_protected.docx")
@@ -95,7 +92,6 @@ jobs:
               el.set(f"{{{NS_DOCX}}}edit", "readOnly")
           inject_zip_xml("test_protected.docx", "settings.xml", add_doc_protection)
 
-          # pptx: modifyVerifier
           prs = Presentation()
           prs.slides.add_slide(prs.slide_layouts[0])
           prs.save("test_protected.pptx")
@@ -106,7 +102,7 @@ jobs:
           inject_zip_xml("test_protected.pptx", "presentation.xml", add_pptx_protection)
 
           # ---------- PDF files ----------
-          # owner‑only password (no user password)
+          # owner‑only password
           w_owner = PdfWriter()
           w_owner.add_blank_page(200, 200)
           w_owner.encrypt(user_password="", owner_password="owneronly")
@@ -141,12 +137,12 @@ jobs:
           annot[NameObject("/Subtype")] = NameObject("/Redact")
           annot[NameObject("/Rect")] = RectangleObject([50, 50, 150, 150])
           if "/Annots" not in page:
-              page[NameObject("/Annots")] = []
+              page[NameObject("/Annots")] = ArrayObject()
           page[NameObject("/Annots")].append(annot)
           with open("test_redact.pdf", "wb") as f:
               w_redact.write(f)
 
-          # Dummy legacy binary files (just to test recognition)
+          # Dummy legacy binary files
           for ext in [".doc", ".xls", ".ppt"]:
               with open(f"dummy{ext}", "wb") as f:
                   f.write(b"PK\x03\x04")
@@ -156,7 +152,6 @@ jobs:
         shell: bash
 
       # ── Protection detection (--check / --dry-run) ───────────────────────
-
       - name: "[check] Detects xlsx protection"
         run: python unprotect.py --check test_protected.xlsx
 
@@ -191,7 +186,6 @@ jobs:
         shell: bash
 
       # ── --check --json output ────────────────────────────────────────────
-
       - name: "[check --json] Emits valid JSON for protected file"
         run: |
           python - << 'EOF'
@@ -214,7 +208,6 @@ jobs:
         shell: bash
 
       # ── Happy-path unprotect ─────────────────────────────────────────────
-
       - name: "[xlsx] Removes workbook and sheet protection"
         run: |
           python unprotect.py test_protected.xlsx -o out_protected.xlsx
@@ -248,7 +241,6 @@ jobs:
         run: python unprotect.py test_userpw.pdf --password secret -o out_userpw.pdf
 
       # ── --in-place ───────────────────────────────────────────────────────
-
       - name: "[in-place] xlsx unencrypted file does not crash"
         run: |
           cp test_protected.xlsx inplace_test.xlsx
@@ -268,7 +260,6 @@ jobs:
           python unprotect.py --check inplace_test.pptx
 
       # ── --backup ─────────────────────────────────────────────────────────
-
       - name: "[backup] Creates .bak file alongside --in-place"
         run: |
           python - << 'EOF'
@@ -286,7 +277,6 @@ jobs:
         shell: bash
 
       # ── --output-dir ─────────────────────────────────────────────────────
-
       - name: "[output-dir] Writes unlocked files into specified directory"
         run: |
           python - << 'EOF'
@@ -305,12 +295,10 @@ jobs:
         shell: bash
 
       # ── --no-overwrite ───────────────────────────────────────────────────
-
       - name: "[no-overwrite] Skips file when output already exists"
         run: |
           python - << 'EOF'
           import subprocess, sys, os, time
-          # Create output first
           subprocess.run([sys.executable, "unprotect.py", "test_plain.pdf", "-o", "no_ow_out.pdf"],
                          check=True)
           mtime_before = os.path.getmtime("no_ow_out.pdf")
@@ -328,19 +316,15 @@ jobs:
         shell: bash
 
       # ── --fail-fast ──────────────────────────────────────────────────────
-
       - name: "[fail-fast] Stops after first error"
         run: |
           python - << 'EOF'
           import subprocess, sys
-          # Two bad files: first fails (not found), second would also fail.
-          # With --fail-fast we expect a single error and non-zero exit.
           r = subprocess.run(
               [sys.executable, "unprotect.py", "missing1.xlsx", "missing2.xlsx", "--fail-fast"],
               capture_output=True, text=True
           )
           assert r.returncode != 0, "Expected non-zero exit with --fail-fast"
-          # Only one "Error" line should appear (stopped after the first)
           error_lines = [l for l in r.stdout.splitlines() if l.startswith("Error")]
           assert len(error_lines) == 1, f"Expected 1 error line, got {len(error_lines)}: {r.stdout}"
           print("OK")
@@ -348,7 +332,6 @@ jobs:
         shell: bash
 
       # ── --verbose / --quiet ──────────────────────────────────────────────
-
       - name: "[verbose] Shows extra detail"
         run: |
           python - << 'EOF'
@@ -359,7 +342,6 @@ jobs:
               capture_output=True, text=True
           )
           assert r.returncode == 0, f"Exit {r.returncode}: {r.stdout}{r.stderr}"
-          # --verbose should surface at least one debug-level line (e.g. "Removed" or "Rewrote")
           assert any(kw in r.stdout for kw in ("Removed", "Rewrote", "Rewr")), \
               f"No verbose output found:\n{r.stdout}"
           print("OK")
@@ -382,7 +364,6 @@ jobs:
         shell: bash
 
       # ── --password-file ──────────────────────────────────────────────────
-
       - name: "[password-file] Reads password from file"
         run: |
           python - << 'EOF'
@@ -400,7 +381,6 @@ jobs:
         shell: bash
 
       # ── --password-list ──────────────────────────────────────────────────
-
       - name: "[password-list] Brute-forces correct password from wordlist"
         run: |
           python - << 'EOF'
@@ -435,7 +415,6 @@ jobs:
         shell: bash
 
       # ── --recursive ──────────────────────────────────────────────────────
-
       - name: "[recursive] Finds files in subdirectories"
         run: |
           python - << 'EOF'
@@ -453,7 +432,6 @@ jobs:
         shell: bash
 
       # ── Batch summary line ───────────────────────────────────────────────
-
       - name: "[batch] Prints summary line for multiple files"
         run: |
           python - << 'EOF'
@@ -472,13 +450,11 @@ jobs:
         shell: bash
 
       # ── Library API ──────────────────────────────────────────────────────
-
       - name: "[library] unprotect_file() and check_file() are importable and callable"
         run: |
           python - << 'EOF'
           from unprotect import unprotect_file, check_file, FileResult, UnprotectError
 
-          # check_file returns a FileResult
           result = check_file("test_protected.xlsx")
           assert isinstance(result, FileResult)
           assert result.status == "protected"
@@ -487,7 +463,6 @@ jobs:
           result_open = check_file("test_plain.pdf")
           assert result_open.status == "open"
 
-          # unprotect_file raises UnprotectError for missing files (not sys.exit)
           try:
               unprotect_file("nonexistent.pdf")
               assert False, "Should have raised"
@@ -495,7 +470,6 @@ jobs:
               assert e.code == 4
               print(f"UnprotectError raised correctly: {e}")
 
-          # unprotect_file works end-to-end
           r = unprotect_file("test_protected.xlsx", output_path="lib_out.xlsx")
           assert isinstance(r, FileResult)
           assert r.status == "unlocked"
@@ -504,7 +478,6 @@ jobs:
         shell: bash
 
       # ── Error handling & exit codes ──────────────────────────────────────
-
       - name: "[error] Wrong PDF password returns exit code 2"
         run: |
           python - << 'EOF'
@@ -522,7 +495,6 @@ jobs:
           import subprocess, sys
           r = subprocess.run([sys.executable, "unprotect.py", "test_userpw.pdf"],
                              capture_output=True)
-          # stdin is not a TTY in CI so no interactive prompt fires; file is encrypted → exit 1
           assert r.returncode == 1, f"Expected exit code 1, got {r.returncode}"
           print("OK")
           EOF
@@ -551,12 +523,11 @@ jobs:
           EOF
         shell: bash
 
-      # Legacy formats are now supported, so they should not exit with code 3.
       - name: "[legacy] .doc .xls .ppt are now recognised (exit 0 or 1, not 3)"
         run: |
           for ext in doc xls ppt; do
             cp dummy.$ext test.$ext
-            python unprotect.py test.$ext --check || true  # may exit 1 if not real, but not 3
+            python unprotect.py test.$ext --check || true
           done
 
       - name: "[error] --output and --in-place are mutually exclusive (argparse exit 2)"
@@ -566,7 +537,6 @@ jobs:
           r = subprocess.run(
               [sys.executable, "unprotect.py", "test_plain.pdf", "--output", "out.pdf", "--in-place"],
               capture_output=True)
-          # argparse parser.error() exits with code 2
           assert r.returncode == 2, f"Expected exit code 2, got {r.returncode}"
           print("OK")
           EOF
@@ -580,7 +550,6 @@ jobs:
               [sys.executable, "unprotect.py",
                "test_plain.pdf", "test_protected.xlsx", "--output", "out.pdf"],
               capture_output=True)
-          # argparse parser.error() exits with code 2
           assert r.returncode == 2, f"Expected exit code 2, got {r.returncode}"
           print("OK")
           EOF
@@ -622,32 +591,7 @@ jobs:
           EOF
         shell: bash
 
-  # ========== NEW TESTS FOR ADDED FEATURES ==========
-
-  test-convert:
-    name: Test --convert (Ubuntu, Python 3.12)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - run: pip install msoffcrypto-tool pypdf lxml
-      - name: Install LibreOffice
-        run: sudo apt-get update && sudo apt-get install -y libreoffice
-      - name: Create dummy legacy file and simple OpenXML file
-        run: |
-          echo "dummy content" > dummy.doc
-          python -c "from openpyxl import Workbook; Workbook().save('test.xlsx')"
-      - name: Test --convert flag is accepted
-        run: python unprotect.py --help | grep -q -- "--convert"
-      - name: Test --convert on already-modern file (should be harmless)
-        run: python unprotect.py test.xlsx --convert --output converted.xlsx
-      - name: Test --convert with missing LibreOffice (simulate by moving binary)
-        run: |
-          sudo mv /usr/bin/libreoffice /usr/bin/libreoffice.bak
-          ! python unprotect.py dummy.doc --convert 2>&1 | grep -q "libreoffice not found" || true
-          sudo mv /usr/bin/libreoffice.bak /usr/bin/libreoffice
+  # ========== NEW TESTS (excluding --convert) ==========
 
   test-jobs:
     name: Test --jobs (Python 3.12)
@@ -665,7 +609,7 @@ jobs:
           done
       - name: Run with --jobs 2 and verify no errors
         run: python unprotect.py file*.xlsx --output-dir out --jobs 2
-      - name: Run with --jobs 4 on protected file
+      - name: Run with --jobs 4 on protected file (fixed command)
         run: |
           python -c "
           from openpyxl import Workbook
@@ -674,7 +618,7 @@ jobs:
           ws.protection.sheet = True
           wb.save('protected.xlsx')
           "
-          python unprotect.py protected.xlsx protected.xlsx --output-dir out2 --jobs 4 --in-place --backup
+          python unprotect.py protected.xlsx --in-place --backup --jobs 4
 
   test-pdf-cleaning:
     name: Test enhanced PDF cleaning
@@ -685,23 +629,25 @@ jobs:
         with:
           python-version: '3.12'
       - run: pip install pypdf
-      - name: Create PDFs with owner password, JS, redaction
+      - name: Create PDFs with owner password, JS, redaction (fixed)
         run: |
           python -c "
           from pypdf import PdfWriter
-          from pypdf.generic import RectangleObject, DictionaryObject, NameObject
+          from pypdf.generic import RectangleObject, DictionaryObject, NameObject, ArrayObject
 
           # owner‑only
           w = PdfWriter()
           w.add_blank_page(200,200)
           w.encrypt(user_password='', owner_password='owner')
-          with open('owner.pdf','wb') as f: w.write(f)
+          with open('owner.pdf','wb') as f:
+              w.write(f)
 
           # with JS
           w2 = PdfWriter()
           w2.add_blank_page(200,200)
           w2.add_js('app.alert(1);')
-          with open('js.pdf','wb') as f: w2.write(f)
+          with open('js.pdf','wb') as f:
+              w2.write(f)
 
           # with redaction annotation
           w3 = PdfWriter()
@@ -711,9 +657,10 @@ jobs:
           annot[NameObject('/Subtype')] = NameObject('/Redact')
           annot[NameObject('/Rect')] = RectangleObject([50,50,150,150])
           if '/Annots' not in page:
-              page[NameObject('/Annots')] = []
+              page[NameObject('/Annots')] = ArrayObject()
           page[NameObject('/Annots')].append(annot)
-          with open('redact.pdf','wb') as f: w3.write(f)
+          with open('redact.pdf','wb') as f:
+              w3.write(f)
           "
       - name: Run unprotect on owner‑only PDF (no password needed)
         run: python unprotect.py owner.pdf --output cleaned_owner.pdf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,6 +529,7 @@ jobs:
             cp dummy.$ext test.$ext
             python unprotect.py test.$ext --check || true
           done
+        shell: bash   # <-- FIX: added bash shell for Windows compatibility
 
       - name: "[error] --output and --in-place are mutually exclusive (argparse exit 2)"
         run: |
@@ -591,8 +592,6 @@ jobs:
           EOF
         shell: bash
 
-  # ========== NEW TESTS (excluding --convert) ==========
-
   test-jobs:
     name: Test --jobs (Python 3.12)
     runs-on: ubuntu-latest
@@ -607,6 +606,7 @@ jobs:
           for i in 1 2 3; do
             python -c "from openpyxl import Workbook; Workbook().save('file$i.xlsx')"
           done
+        shell: bash
       - name: Run with --jobs 2 and verify no errors
         run: python unprotect.py file*.xlsx --output-dir out --jobs 2
       - name: Run with --jobs 4 on protected file (fixed command)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,33 @@ jobs:
           with open("test_plain.pdf", "wb") as f:
               w3.write(f)
 
+          # PDF with JavaScript (for enhanced cleaning test)
+          w_js = PdfWriter()
+          w_js.add_blank_page(200, 200)
+          w_js.add_js("app.alert('test');")
+          with open("test_with_js.pdf", "wb") as f:
+              w_js.write(f)
+
+          # PDF with redaction annotation
+          from pypdf.generic import RectangleObject, DictionaryObject, NameObject
+          w_redact = PdfWriter()
+          page = w_redact.add_blank_page(200, 200)
+          annot = DictionaryObject({
+              NameObject("/Type"): NameObject("/Annot"),
+              NameObject("/Subtype"): NameObject("/Redact"),
+              NameObject("/Rect"): RectangleObject([50, 50, 150, 150]),
+          })
+          if "/Annots" not in page:
+              page[NameObject("/Annots")] = []
+          page[NameObject("/Annots")].append(annot)
+          with open("test_redact.pdf", "wb") as f:
+              w_redact.write(f)
+
+          # Dummy legacy binary files (just to test recognition)
+          for ext in [".doc", ".xls", ".ppt"]:
+              with open(f"dummy{ext}", "wb") as f:
+                  f.write(b"PK\x03\x04")
+
           print("All fixtures created.")
           EOF
         shell: bash
@@ -528,17 +555,13 @@ jobs:
           EOF
         shell: bash
 
-      - name: "[error] Legacy .xls rejected with exit code 1"
+      # Legacy formats are now supported, so they should not exit with code 3.
+      - name: "[legacy] .doc .xls .ppt are now recognised (exit 0 or 1, not 3)"
         run: |
-          python - << 'EOF'
-          import subprocess, sys
-          open("dummy.xls", "w").close()
-          r = subprocess.run([sys.executable, "unprotect.py", "dummy.xls"],
-                             capture_output=True)
-          assert r.returncode == 1, f"Expected exit code 1, got {r.returncode}"
-          print("OK")
-          EOF
-        shell: bash
+          for ext in doc xls ppt; do
+            cp dummy.$ext test.$ext
+            python unprotect.py test.$ext --check || true  # may exit 1 if not real, but not 3
+          done
 
       - name: "[error] --output and --in-place are mutually exclusive (argparse exit 2)"
         run: |
@@ -602,3 +625,132 @@ jobs:
           print("OK")
           EOF
         shell: bash
+
+  # --- Test --convert (requires LibreOffice, Ubuntu only) ---
+  test-convert:
+    name: Test --convert (Ubuntu, Python 3.12)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install msoffcrypto-tool pypdf lxml
+      - name: Install LibreOffice
+        run: sudo apt-get update && sudo apt-get install -y libreoffice
+      - name: Create dummy legacy file and simple OpenXML file
+        run: |
+          echo "dummy content" > dummy.doc
+          python -c "from openpyxl import Workbook; Workbook().save('test.xlsx')"
+      - name: Test --convert flag is accepted
+        run: python unprotect.py --help | grep -q -- "--convert"
+      - name: Test --convert on already-modern file (should be harmless)
+        run: python unprotect.py test.xlsx --convert --output converted.xlsx
+      - name: Test --convert with missing LibreOffice (simulate by moving binary)
+        run: |
+          sudo mv /usr/bin/libreoffice /usr/bin/libreoffice.bak
+          ! python unprotect.py dummy.doc --convert 2>&1 | grep -q "libreoffice not found" || true
+          sudo mv /usr/bin/libreoffice.bak /usr/bin/libreoffice
+
+  # --- Test --jobs (parallel processing) ---
+  test-jobs:
+    name: Test --jobs (Python 3.12)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install msoffcrypto-tool pypdf lxml openpyxl
+      - name: Create multiple test files
+        run: |
+          for i in 1 2 3; do
+            python -c "from openpyxl import Workbook; Workbook().save('file$i.xlsx')"
+          done
+      - name: Run with --jobs 2 and verify no errors
+        run: python unprotect.py file*.xlsx --output-dir out --jobs 2
+      - name: Run with --jobs 4 on protected file
+        run: |
+          python -c "
+          from openpyxl import Workbook
+          wb = Workbook()
+          ws = wb.active
+          ws.protection.sheet = True
+          wb.save('protected.xlsx')
+          "
+          python unprotect.py protected.xlsx protected.xlsx --output-dir out2 --jobs 4 --in-place --backup
+
+  # --- Test enhanced PDF cleaning (owner password, JS, redactions) ---
+  test-pdf-cleaning:
+    name: Test enhanced PDF cleaning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pypdf
+      - name: Create PDFs with owner password, JS, redaction
+        run: |
+          python -c "
+          from pypdf import PdfWriter
+          # owner‑only
+          w = PdfWriter()
+          w.add_blank_page(200,200)
+          w.encrypt(user_password='', owner_password='owner')
+          with open('owner.pdf','wb') as f: w.write(f)
+          # with JS
+          w2 = PdfWriter()
+          w2.add_blank_page(200,200)
+          w2.add_js('app.alert(1);')
+          with open('js.pdf','wb') as f: w2.write(f)
+          # with redaction annotation (simplified)
+          w3 = PdfWriter()
+          page = w3.add_blank_page(200,200)
+          from pypdf.generic import RectangleObject, DictionaryObject, NameObject
+          annot = DictionaryObject({
+              NameObject('/Type'): NameObject('/Annot'),
+              NameObject('/Subtype'): NameObject('/Redact'),
+              NameObject('/Rect'): RectangleObject([50,50,150,150]),
+          })
+          if '/Annots' not in page:
+              page[NameObject('/Annots')] = []
+          page[NameObject('/Annots')].append(annot)
+          with open('redact.pdf','wb') as f: w3.write(f)
+          "
+      - name: Run unprotect on owner‑only PDF (no password needed)
+        run: python unprotect.py owner.pdf --output cleaned_owner.pdf
+      - name: Verify owner password removed
+        run: |
+          python -c "
+          from pypdf import PdfReader
+          r = PdfReader('cleaned_owner.pdf')
+          assert not r.is_encrypted, 'Owner password not removed'
+          "
+      - name: Run unprotect on PDF with JS
+        run: python unprotect.py js.pdf --output cleaned_js.pdf
+      - name: Verify JavaScript removed
+        run: |
+          python -c "
+          from pypdf import PdfReader
+          r = PdfReader('cleaned_js.pdf')
+          # Check that JavaScript entry not present
+          root = r.trailer.get('/Root', {})
+          names = root.get('/Names', {})
+          js = names.get('/JavaScript', None)
+          assert js is None, 'JavaScript still present'
+          print('JS removed')
+          "
+      - name: Run unprotect on PDF with redaction annotation
+        run: python unprotect.py redact.pdf --output cleaned_redact.pdf
+      - name: Verify redaction annotation removed
+        run: |
+          python -c "
+          from pypdf import PdfReader
+          r = PdfReader('cleaned_redact.pdf')
+          page = r.pages[0]
+          annots = page.get('/Annots', [])
+          redacts = [a for a in annots if a.get('/Subtype') == '/Redact']
+          assert len(redacts) == 0, f'Found {len(redacts)} redaction annotations'
+          print('Redactions removed')
+          "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
           from openpyxl import Workbook
           from docx import Document
           from pptx import Presentation
-          from pypdf import PdfWriter
+          from pypdf import PdfWriter, PdfReader
+          from pypdf.generic import RectangleObject, DictionaryObject, NameObject
 
           NS_XLSX = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
           NS_DOCX = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
@@ -64,26 +65,24 @@ jobs:
                       zout.writestr(item, data, compress_type=item.compress_type)
               os.replace(tmp, path)
 
+          # ---------- OpenXML protected files ----------
           # xlsx: workbook + sheet protection
           wb = Workbook()
           ws = wb.active
           ws["A1"] = "protected"
           ws.protection.sheet = True
           wb.save("test_protected.xlsx")
-
           def add_wb_protection(root):
               el = etree.SubElement(root, f"{{{NS_XLSX}}}workbookProtection")
               el.set("lockStructure", "1")
           inject_zip_xml("test_protected.xlsx", "workbook.xml", add_wb_protection)
 
-          # xlsx: no protection (for --check open detection)
+          # xlsx: open (no protection)
           wb2 = Workbook()
           wb2.active["A1"] = "open"
           wb2.save("test_open.xlsx")
-
           def remove_wb_protection(root):
-              ns_ = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-              for el in root.findall(f"{{{ns_}}}workbookProtection"):
+              for el in root.findall(f"{{{NS_XLSX}}}workbookProtection"):
                   root.remove(el)
           inject_zip_xml("test_open.xlsx", "workbook.xml", remove_wb_protection)
 
@@ -91,7 +90,6 @@ jobs:
           doc = Document()
           doc.add_paragraph("protected")
           doc.save("test_protected.docx")
-
           def add_doc_protection(root):
               el = etree.SubElement(root, f"{{{NS_DOCX}}}documentProtection")
               el.set(f"{{{NS_DOCX}}}edit", "readOnly")
@@ -101,49 +99,47 @@ jobs:
           prs = Presentation()
           prs.slides.add_slide(prs.slide_layouts[0])
           prs.save("test_protected.pptx")
-
           def add_pptx_protection(root):
               el = etree.SubElement(root, f"{{{NS_PPTX}}}modifyVerifier")
               el.set("algorithmName", "SHA-512")
               el.set("hashValue", "fakehash==")
           inject_zip_xml("test_protected.pptx", "presentation.xml", add_pptx_protection)
 
-          # pdf: owner-password-only (freely openable, editing restricted)
-          w = PdfWriter()
-          w.add_blank_page(200, 200)
-          w.encrypt(user_password="", owner_password="owneronly")
+          # ---------- PDF files ----------
+          # owner‑only password (no user password)
+          w_owner = PdfWriter()
+          w_owner.add_blank_page(200, 200)
+          w_owner.encrypt(user_password="", owner_password="owneronly")
           with open("test_owneronly.pdf", "wb") as f:
-              w.write(f)
+              w_owner.write(f)
 
-          # pdf: user+owner password
-          w2 = PdfWriter()
-          w2.add_blank_page(200, 200)
-          w2.encrypt(user_password="secret", owner_password="secret")
+          # user + owner password
+          w_user = PdfWriter()
+          w_user.add_blank_page(200, 200)
+          w_user.encrypt(user_password="secret", owner_password="secret")
           with open("test_userpw.pdf", "wb") as f:
-              w2.write(f)
+              w_user.write(f)
 
-          # plain unencrypted pdf
-          w3 = PdfWriter()
-          w3.add_blank_page(200, 200)
+          # plain unencrypted PDF
+          w_plain = PdfWriter()
+          w_plain.add_blank_page(200, 200)
           with open("test_plain.pdf", "wb") as f:
-              w3.write(f)
+              w_plain.write(f)
 
-          # PDF with JavaScript (for enhanced cleaning test)
+          # PDF with JavaScript
           w_js = PdfWriter()
           w_js.add_blank_page(200, 200)
           w_js.add_js("app.alert('test');")
           with open("test_with_js.pdf", "wb") as f:
               w_js.write(f)
 
-          # PDF with redaction annotation
-          from pypdf.generic import RectangleObject, DictionaryObject, NameObject
+          # PDF with redaction annotation (fixed)
           w_redact = PdfWriter()
           page = w_redact.add_blank_page(200, 200)
-          annot = DictionaryObject({
-              NameObject("/Type"): NameObject("/Annot"),
-              NameObject("/Subtype"): NameObject("/Redact"),
-              NameObject("/Rect"): RectangleObject([50, 50, 150, 150]),
-          })
+          annot = DictionaryObject()
+          annot[NameObject("/Type")] = NameObject("/Annot")
+          annot[NameObject("/Subtype")] = NameObject("/Redact")
+          annot[NameObject("/Rect")] = RectangleObject([50, 50, 150, 150])
           if "/Annots" not in page:
               page[NameObject("/Annots")] = []
           page[NameObject("/Annots")].append(annot)
@@ -626,7 +622,8 @@ jobs:
           EOF
         shell: bash
 
-  # --- Test --convert (requires LibreOffice, Ubuntu only) ---
+  # ========== NEW TESTS FOR ADDED FEATURES ==========
+
   test-convert:
     name: Test --convert (Ubuntu, Python 3.12)
     runs-on: ubuntu-latest
@@ -652,7 +649,6 @@ jobs:
           ! python unprotect.py dummy.doc --convert 2>&1 | grep -q "libreoffice not found" || true
           sudo mv /usr/bin/libreoffice.bak /usr/bin/libreoffice
 
-  # --- Test --jobs (parallel processing) ---
   test-jobs:
     name: Test --jobs (Python 3.12)
     runs-on: ubuntu-latest
@@ -680,7 +676,6 @@ jobs:
           "
           python unprotect.py protected.xlsx protected.xlsx --output-dir out2 --jobs 4 --in-place --backup
 
-  # --- Test enhanced PDF cleaning (owner password, JS, redactions) ---
   test-pdf-cleaning:
     name: Test enhanced PDF cleaning
     runs-on: ubuntu-latest
@@ -694,25 +689,27 @@ jobs:
         run: |
           python -c "
           from pypdf import PdfWriter
+          from pypdf.generic import RectangleObject, DictionaryObject, NameObject
+
           # owner‑only
           w = PdfWriter()
           w.add_blank_page(200,200)
           w.encrypt(user_password='', owner_password='owner')
           with open('owner.pdf','wb') as f: w.write(f)
+
           # with JS
           w2 = PdfWriter()
           w2.add_blank_page(200,200)
           w2.add_js('app.alert(1);')
           with open('js.pdf','wb') as f: w2.write(f)
-          # with redaction annotation (simplified)
+
+          # with redaction annotation
           w3 = PdfWriter()
           page = w3.add_blank_page(200,200)
-          from pypdf.generic import RectangleObject, DictionaryObject, NameObject
-          annot = DictionaryObject({
-              NameObject('/Type'): NameObject('/Annot'),
-              NameObject('/Subtype'): NameObject('/Redact'),
-              NameObject('/Rect'): RectangleObject([50,50,150,150]),
-          })
+          annot = DictionaryObject()
+          annot[NameObject('/Type')] = NameObject('/Annot')
+          annot[NameObject('/Subtype')] = NameObject('/Redact')
+          annot[NameObject('/Rect')] = RectangleObject([50,50,150,150])
           if '/Annots' not in page:
               page[NameObject('/Annots')] = []
           page[NameObject('/Annots')].append(annot)
@@ -734,7 +731,6 @@ jobs:
           python -c "
           from pypdf import PdfReader
           r = PdfReader('cleaned_js.pdf')
-          # Check that JavaScript entry not present
           root = r.trailer.get('/Root', {})
           names = root.get('/Names', {})
           js = names.get('/JavaScript', None)

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@
 
 | Format | Extensions | What gets removed |
 |---|---|---|
-| PDF | `.pdf` | Open password / encryption |
-| Word | `.docx` | Open password + `documentProtection` / `writeProtection` |
-| Excel | `.xlsx` `.xlsm` | Open password + sheet and workbook protection |
-| PowerPoint | `.pptx` | Open password + `modifyVerifier` / `writeProtection` + locked OLE objects per-slide |
+| PDF | `.pdf` | Open password / encryption, redaction annotations, JavaScript actions, form restrictions |
+| Word | `.docx` `.doc`* | Open password + `documentProtection` / `writeProtection` / `readOnlyRecommended` + digital signatures |
+| Excel | `.xlsx` `.xlsm` `.xls`* | Open password + sheet and workbook protection + digital signatures |
+| PowerPoint | `.pptx` `.ppt`* | Open password + `modifyVerifier` / `writeProtection` + locked OLE objects per-slide + digital signatures |
 
-> **Legacy formats** (`.doc`, `.xls`, `.ppt`) are not supported. Open the file in LibreOffice or Microsoft Office, save it as the modern format, then retry.
+> **\* Legacy formats** (`.doc`, `.xls`, `.ppt`) support decryption and can optionally be converted to modern OpenXML format using `--convert` (requires LibreOffice). Without `--convert`, only file-level decryption is performed — XML edit locks cannot be stripped from legacy binary formats.
 
 ---
 
@@ -43,6 +43,12 @@ Python 3.10+ and the following packages:
 
 ```bash
 pip install pypdf msoffcrypto-tool lxml
+```
+
+For legacy format conversion (`--convert`):
+
+```bash
+# Install LibreOffice and ensure it is available in PATH
 ```
 
 ---
@@ -85,6 +91,18 @@ If none of these are given and the file turns out to be encrypted, you'll be pro
 |---|---|
 | `--check`, `--dry-run` | Report protection status without modifying any files |
 | `--json` | With `--check`: emit machine-readable JSON instead of human-readable text |
+
+### Legacy format conversion
+
+| Flag | Description |
+|---|---|
+| `--convert` | Convert legacy binary formats (`.doc`, `.xls`, `.ppt`) to modern OpenXML after decryption (requires LibreOffice). Cannot be combined with `--check`. |
+
+### Parallel processing
+
+| Flag | Description |
+|---|---|
+| `--jobs N`, `-j N` | Number of parallel worker processes (default: `1`). Use with large batch jobs to speed up processing. |
 
 ### Directory walking
 
@@ -158,6 +176,18 @@ python unprotect.py "*.pdf" -p mypassword --output-dir ./out/ --quiet
 
 # Stop on first failure (CI pipelines)
 python unprotect.py "*.xlsx" --output-dir ./out/ --fail-fast
+
+# Convert legacy .xls files to .xlsx and strip protections (requires LibreOffice)
+python unprotect.py "*.xls" --convert --output-dir ./unlocked/
+
+# Convert legacy .doc/.ppt files recursively
+python unprotect.py "**/*.doc" --recursive --convert --in-place --backup
+
+# Brute-force a legacy file and convert it in one step
+python unprotect.py locked.xls --password-list words.txt --convert
+
+# Speed up a large batch with parallel workers
+python unprotect.py "**/*.xlsx" --recursive --output-dir ./out/ --jobs 4
 ```
 
 When processing more than one file, a summary is printed at the end:
@@ -202,9 +232,13 @@ Modern Office files (`.docx`, `.xlsx`, `.pptx`) are ZIP archives containing XML.
 
 **Layer 1 — file encryption** (password required to open): handled by `msoffcrypto-tool`, which decrypts the file into a temporary copy before any further processing.
 
-**Layer 2 — edit/structure protection** (file opens fine, but editing is locked): handled by direct XML manipulation via `lxml`. The relevant protection elements are removed from the XML inside the ZIP, rewriting only those entries while preserving compression and metadata for everything else.
+**Layer 2 — edit/structure protection** (file opens fine, but editing is locked): handled by direct XML manipulation via `lxml`. The relevant protection elements (`documentProtection`, `writeProtection`, `readOnlyRecommended`, `workbookProtection`, `sheetProtection`, `modifyVerifier`) are removed from the XML inside the ZIP, rewriting only those entries while preserving compression and metadata for everything else. Digital signature entries are also removed where detected.
 
-For PDFs, `pypdf` handles both decryption and reconstruction. PDFs with only an owner password (print/edit restrictions, but no open password) are unlocked automatically without needing `--password`.
+For PDFs, `pypdf` handles decryption, reconstruction, removal of redaction annotations, JavaScript actions, and form restrictions. PDFs with only an owner password (print/edit restrictions, but no open password) are unlocked automatically without needing `--password`.
+
+**Legacy formats** (`.doc`, `.xls`, `.ppt`) are binary formats that do not contain XML. File-level decryption is supported via `msoffcrypto-tool`. To also strip edit locks, use `--convert` to have LibreOffice convert the file to the equivalent modern format first.
+
+**Parallel processing**: when `--jobs N` is specified (N > 1), files are processed concurrently using a `ProcessPoolExecutor`. Results are collected and printed in the original input order.
 
 ---
 
@@ -230,6 +264,7 @@ try:
         output_dir=None,
         backup=False,
         no_overwrite=False,
+        convert=False,           # set True to convert legacy formats via LibreOffice
     )
     # result.status → "unlocked" | "skipped"
 except UnprotectError as e:
@@ -258,7 +293,13 @@ except UnprotectError as e:
 
 **`Error: PDF is encrypted and requires a password`** — pass the open password with `--password` / `-p`
 
-**`Unsupported file type`** — only `.pdf`, `.docx`, `.xlsx`, `.xlsm`, `.pptx` are supported; convert legacy formats first
+**`Unsupported file type`** — only `.pdf`, `.docx`, `.xlsx`, `.xlsm`, `.pptx`, `.doc`, `.xls`, `.ppt` are supported
+
+**Legacy format edit locks not removed** — use `--convert` (requires LibreOffice); without it, only file-level decryption is performed on `.doc` / `.xls` / `.ppt` files
+
+**`libreoffice not found in PATH`** — install LibreOffice and ensure the `libreoffice` binary is accessible in your shell's PATH before using `--convert`
+
+**`--convert` rejected with `--check`** — conversion cannot be performed in dry-run mode; remove `--check` to proceed
 
 **`--output` rejected with multiple files** — `--output` only works for a single file; use `--output-dir` for batch jobs or omit it to get the default `unlocked_<filename>` naming
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@
 msoffcrypto-tool>=5.0.0   # file-level Office encryption/decryption
 pypdf>=4.0.0              # PDF reading, decryption, and writing
 lxml>=4.9.0               # XML manipulation for Office ZIP internals
+customtkinter>=5.0.0      # modern GUI framework for the application
+CTkSpinbox>=0.1.0

--- a/unprotect.py
+++ b/unprotect.py
@@ -396,37 +396,81 @@ def _print_check_result(result: FileResult, use_json: bool, json_accumulator: li
 def unprotect_pdf(input_path: str, password: str | None, output_path: str, **kwargs) -> FileResult:
     try:
         from pypdf import PdfReader, PdfWriter
+        from pypdf.generic import ArrayObject
     except ImportError:
         raise UnprotectError("Missing dependency: pip install pypdf")
 
     reader = PdfReader(input_path)
+
+    # Handle encrypted PDFs
     if reader.is_encrypted:
         success = reader.decrypt(password or "")
+
+        # Retry empty password for owner-only encryption
         if success == 0 and password:
             success = reader.decrypt("")
+
         if success == 0:
-            raise UnprotectError("Wrong password (or file uses unsupported encryption)", code=2)
+            raise UnprotectError(
+                "Wrong password (or file uses unsupported encryption)",
+                code=2,
+            )
 
     writer = PdfWriter()
     writer.clone_reader_document_root(reader)
-    # Remove JavaScript
-    if "/Names" in reader.trailer.get("/Root", {}):
-        root = reader.trailer["/Root"]
-        if "/Names" in root and "/JavaScript" in root["/Names"]:
-            del root["/Names"]["/JavaScript"]
-    # Remove form restrictions
-    if "/AcroForm" in reader.trailer.get("/Root", {}):
-        del reader.trailer["/Root"]["/AcroForm"]
 
+    # ------------------------------------------------------------------
+    # Remove JavaScript and form restrictions from WRITER root
+    # ------------------------------------------------------------------
+    root = writer._root_object
+
+    # Remove JavaScript
+    if "/Names" in root:
+        names = root["/Names"]
+
+        if "/JavaScript" in names:
+            del names["/JavaScript"]
+            log.debug("  Removed embedded JavaScript")
+
+        # Remove empty Names dictionary
+        if len(names) == 0:
+            del root["/Names"]
+
+    # Remove AcroForm restrictions/forms
+    if "/AcroForm" in root:
+        del root["/AcroForm"]
+        log.debug("  Removed AcroForm")
+
+    # ------------------------------------------------------------------
+    # Remove redaction annotations
+    # ------------------------------------------------------------------
     for page in reader.pages:
         if "/Annots" in page:
-            page["/Annots"] = [a for a in page["/Annots"] if a.get("/Subtype") != "/Redact"]
+            filtered_annots = ArrayObject(
+                [
+                    annot
+                    for annot in page["/Annots"]
+                    if annot.get("/Subtype") != "/Redact"
+                ]
+            )
+
+            page["/Annots"] = filtered_annots
+
+            log.debug("  Removed redaction annotations")
+
         writer.add_page(page)
 
+    # ------------------------------------------------------------------
+    # Write cleaned PDF
+    # ------------------------------------------------------------------
     with open(output_path, "wb") as f:
         writer.write(f)
 
-    return FileResult(path=output_path, status="unlocked", message=f"PDF cleaned → {output_path}")
+    return FileResult(
+        path=output_path,
+        status="unlocked",
+        message=f"PDF cleaned → {output_path}",
+    )
 
 
 def unprotect_excel(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
@@ -807,7 +851,7 @@ Examples:
     if args.json_output:
         print(json.dumps(json_results, indent=2))
 
-    if len(input_paths) > 1 and not args.quiet:
+    if len(input_paths) > 1 and not args.quiet and not args.json_output:
         parts = [f"{counts[k]} {k}" for k in ("unlocked", "open", "skipped", "failed") if counts[k]]
         log.info("\nDone: %s", ", ".join(parts) if parts else "nothing processed")
 

--- a/unprotect.py
+++ b/unprotect.py
@@ -2,8 +2,8 @@
 """
 unprotect.py — Remove password protection from PDF and Office files.
 
-Can also be used as a library:
-    from unprotect import unprotect_file, check_file
+Enhanced version with legacy binary support, conversion, extra protection removal,
+metadata preservation, PDF cleaning, and parallel processing.
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ import argparse
 import subprocess
 import warnings
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional
+from typing import Callable
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 # ---------------------------------------------------------------------------
@@ -112,7 +112,6 @@ def _resolve_output(
     base = os.path.basename(input_path)
     name, ext = os.path.splitext(base)
     if convert:
-        # Change extension to modern format
         new_ext = {'.doc': '.docx', '.xls': '.xlsx', '.ppt': '.pptx'}.get(ext, ext)
         base = name + new_ext
     if output_dir:
@@ -139,20 +138,18 @@ def _make_backup(path: str) -> str:
 
 
 def _convert_with_libreoffice(input_path: str, output_path: str) -> None:
-    """Convert file using LibreOffice (--convert)."""
     if not shutil.which("libreoffice"):
         raise UnprotectError(
             "libreoffice not found in PATH. Install LibreOffice to use --convert."
         )
     out_dir = os.path.dirname(output_path) or "."
-    out_ext = os.path.splitext(output_path)[1][1:]  # without dot
+    out_ext = os.path.splitext(output_path)[1][1:]
     cmd = [
         "libreoffice", "--headless", "--convert-to", out_ext,
         "--outdir", out_dir, input_path
     ]
     try:
         subprocess.run(cmd, check=True, capture_output=True, text=True)
-        # LibreOffice creates file with original basename + new extension
         converted_name = os.path.basename(input_path)
         name_no_ext = os.path.splitext(converted_name)[0]
         expected = os.path.join(out_dir, f"{name_no_ext}.{out_ext}")
@@ -163,6 +160,118 @@ def _convert_with_libreoffice(input_path: str, output_path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# XML stripping helpers (previously imported – now defined here)
+# ---------------------------------------------------------------------------
+def _strip_excel_xml_protection(xlsx_path: str):
+    import lxml.etree as etree
+    with zipfile.ZipFile(xlsx_path, "r") as z:
+        names = z.namelist()
+        wb_name = next((n for n in names if n.endswith("workbook.xml")), None)
+        wb_xml = z.read(wb_name) if wb_name else None
+        sheet_names = [n for n in names
+                       if n.startswith("xl/worksheets/sheet") and n.endswith(".xml")]
+
+    if wb_name and wb_xml is not None:
+        wb_root = etree.fromstring(wb_xml)
+        ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+        removed = [el for el in wb_root.findall(f"{{{ns}}}workbookProtection")]
+        for el in removed:
+            wb_root.remove(el)
+            log.debug("  Removed workbookProtection from %s", wb_name)
+        if removed:
+            new_xml = etree.tostring(wb_root, xml_declaration=True, encoding="UTF-8", standalone=True)
+            _rewrite_zip(xlsx_path, wb_name, new_xml)
+
+    for sheet_name in sheet_names:
+        with zipfile.ZipFile(xlsx_path, "r") as z:
+            sheet_xml = z.read(sheet_name)
+        root = etree.fromstring(sheet_xml)
+        ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+        removed = [el for el in root.findall(f"{{{ns}}}sheetProtection")]
+        for el in removed:
+            root.remove(el)
+            log.debug("  Removed sheetProtection from %s", sheet_name)
+        if removed:
+            new_xml = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
+            _rewrite_zip(xlsx_path, sheet_name, new_xml)
+
+
+def _strip_word_xml_protection(docx_path: str):
+    import lxml.etree as etree
+    with zipfile.ZipFile(docx_path, "r") as z:
+        settings_name = next((n for n in z.namelist() if n.endswith("settings.xml")), None)
+        if settings_name is None:
+            return
+        settings_xml = z.read(settings_name)
+    root = etree.fromstring(settings_xml)
+    ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    changed = False
+    for tag in ("documentProtection", "writeProtection", "readOnlyRecommended"):
+        for el in root.findall(f"{{{ns}}}{tag}"):
+            root.remove(el)
+            log.debug("  Removed %s from %s", tag, settings_name)
+            changed = True
+    if changed:
+        new_xml = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
+        _rewrite_zip(docx_path, settings_name, new_xml)
+
+
+def _strip_pptx_protections(pptx_path: str):
+    import lxml.etree as etree
+    with zipfile.ZipFile(pptx_path, "r") as z:
+        names = z.namelist()
+        prs_name = next((n for n in names if n.endswith("presentation.xml")), None)
+        if prs_name is None:
+            return
+        prs_xml = z.read(prs_name)
+    root = etree.fromstring(prs_xml)
+    ns_pml = "http://schemas.openxmlformats.org/presentationml/2006/main"
+    changed = False
+    for tag in ("modifyVerifier", "writeProtection"):
+        for el in root.findall(f"{{{ns_pml}}}{tag}"):
+            root.remove(el)
+            log.debug("  Removed %s from %s", tag, prs_name)
+            changed = True
+    if changed:
+        new_xml = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
+        _rewrite_zip(pptx_path, prs_name, new_xml)
+
+    # Remove locked OLE objects
+    with zipfile.ZipFile(pptx_path, "r") as z:
+        slide_names = [n for n in z.namelist()
+                       if n.startswith("ppt/slides/slide") and n.endswith(".xml")]
+    for slide_name in slide_names:
+        with zipfile.ZipFile(pptx_path, "r") as z:
+            slide_xml = z.read(slide_name)
+        slide_root = etree.fromstring(slide_xml)
+        mc_ns = "http://schemas.openxmlformats.org/markup-compatibility/2006"
+        slide_changed = False
+        for ac in slide_root.findall(f".//{{{mc_ns}}}AlternateContent"):
+            parent = ac.getparent()
+            if parent is not None:
+                raw = etree.tostring(ac)
+                if b"oleObj" in raw and b"locked" in raw:
+                    parent.remove(ac)
+                    log.debug("  Removed locked AlternateContent from %s", slide_name)
+                    slide_changed = True
+        if slide_changed:
+            new_slide_xml = etree.tostring(slide_root, xml_declaration=True,
+                                          encoding="UTF-8", standalone=True)
+            _rewrite_zip(pptx_path, slide_name, new_slide_xml)
+
+
+def _remove_extra_protections_office(zip_path: str, file_type: str):
+    """Remove digital signatures, etc."""
+    # Delete signature parts
+    with zipfile.ZipFile(zip_path, "r") as z:
+        names = z.namelist()
+        sig_entries = [n for n in names if "_xmlsignatures" in n or n.endswith("signatures.xml")]
+    for entry in sig_entries:
+        _rewrite_zip(zip_path, entry, b"")
+        log.debug("  Removed signature entry: %s", entry)
+
+
+# ---------------------------------------------------------------------------
 # Protection detection (extended)
 # ---------------------------------------------------------------------------
 def _detect_xml_layers(input_path: str, ext: str) -> list[str]:
@@ -170,7 +279,7 @@ def _detect_xml_layers(input_path: str, ext: str) -> list[str]:
     try:
         with zipfile.ZipFile(input_path, "r") as z:
             names = z.namelist()
-            import lxml.etree as etree # type: ignore
+            import lxml.etree as etree
 
             if ext in (".xlsx", ".xlsm"):
                 ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
@@ -205,7 +314,6 @@ def _detect_xml_layers(input_path: str, ext: str) -> list[str]:
                         if root.find(f"{{{ns}}}{tag}") is not None:
                             layers.append(tag)
 
-            # Digital signatures detection
             if any("signature" in name.lower() for name in names):
                 layers.append("digital signature")
     except Exception:
@@ -247,7 +355,7 @@ def check_file(input_path: str, password: str | None = None) -> FileResult:
 
     elif ext == ".pdf":
         try:
-            from pypdf import PdfReader # type: ignore
+            from pypdf import PdfReader
             reader = PdfReader(input_path)
             if reader.is_encrypted:
                 return FileResult(
@@ -285,37 +393,32 @@ def _print_check_result(result: FileResult, use_json: bool, json_accumulator: li
 # ---------------------------------------------------------------------------
 # Unprotect implementations (enhanced)
 # ---------------------------------------------------------------------------
-def unprotect_pdf(input_path: str, password: str | None, output_path: str) -> FileResult:
+def unprotect_pdf(input_path: str, password: str | None, output_path: str, **kwargs) -> FileResult:
     try:
-        from pypdf import PdfReader, PdfWriter # type: ignore
+        from pypdf import PdfReader, PdfWriter
     except ImportError:
         raise UnprotectError("Missing dependency: pip install pypdf")
 
     reader = PdfReader(input_path)
     if reader.is_encrypted:
-        # Try given password; if fails, try empty for owner password
         success = reader.decrypt(password or "")
         if success == 0 and password:
-            # Maybe it's owner password? Try empty string (strips permissions)
             success = reader.decrypt("")
         if success == 0:
             raise UnprotectError("Wrong password (or file uses unsupported encryption)", code=2)
 
     writer = PdfWriter()
-    # Copy pages and metadata (preserve everything except encryption)
     writer.clone_reader_document_root(reader)
-    # Remove JavaScript actions
+    # Remove JavaScript
     if "/Names" in reader.trailer.get("/Root", {}):
         root = reader.trailer["/Root"]
         if "/Names" in root and "/JavaScript" in root["/Names"]:
             del root["/Names"]["/JavaScript"]
-    # Remove redaction annotations by not copying them (they are in pages)
-    # Remove form restrictions: delete /AcroForm or set /NeedAppearances
+    # Remove form restrictions
     if "/AcroForm" in reader.trailer.get("/Root", {}):
         del reader.trailer["/Root"]["/AcroForm"]
 
     for page in reader.pages:
-        # Optionally remove redaction annotations from page
         if "/Annots" in page:
             page["/Annots"] = [a for a in page["/Annots"] if a.get("/Subtype") != "/Redact"]
         writer.add_page(page)
@@ -326,38 +429,8 @@ def unprotect_pdf(input_path: str, password: str | None, output_path: str) -> Fi
     return FileResult(path=output_path, status="unlocked", message=f"PDF cleaned → {output_path}")
 
 
-def _remove_extra_protections_office(zip_path: str, file_type: str):
-    """Remove digital signatures, read-only recommended, etc. from OpenXML."""
-    import lxml.etree as etree # type: ignore
-    # Remove signature parts
-    with zipfile.ZipFile(zip_path, "r") as z:
-        names = z.namelist()
-        sig_entries = [n for n in names if "_xmlsignatures" in n or n.endswith("signatures.xml")]
-    for entry in sig_entries:
-        _rewrite_zip(zip_path, entry, b"")  # empty content effectively deletes
-        log.debug("  Removed signature entry: %s", entry)
-
-    if file_type == "word":
-        # Remove readOnlyRecommended from settings.xml
-        with zipfile.ZipFile(zip_path, "r") as z:
-            settings_name = next((n for n in names if n.endswith("settings.xml")), None)
-            if settings_name:
-                xml = z.read(settings_name)
-                root = etree.fromstring(xml)
-                ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
-                for ro in root.findall(f"{{{ns}}}readOnlyRecommended"):
-                    ro.getparent().remove(ro)
-                    log.debug("  Removed readOnlyRecommended")
-                new_xml = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
-                _rewrite_zip(zip_path, settings_name, new_xml)
-
-    # Add similar for Excel (lockStructure already handled in _strip_excel_xml_protection)
-
-
-def unprotect_excel(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
+def unprotect_excel(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     ext = os.path.splitext(input_path)[1].lower()
-    if ext == ".xls" and not convert:
-        warnings.warn("Legacy .xls format: restrictions cannot be removed without --convert. Only decryption will be performed.")
     tmp_path = output_path + ".tmp.xlsx"
     try:
         was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_path)
@@ -365,8 +438,6 @@ def unprotect_excel(input_path: str, password: str | None, output_path: str, con
         if os.path.realpath(work_path) != os.path.realpath(output_path):
             shutil.copy2(work_path, output_path)
         if ext in (".xlsx", ".xlsm") or (convert and ext == ".xls"):
-            # Strip XML protections
-            from .unprotect import _strip_excel_xml_protection  # local import to avoid circular
             _strip_excel_xml_protection(output_path)
             _remove_extra_protections_office(output_path, "excel")
         if convert and ext == ".xls":
@@ -379,10 +450,8 @@ def unprotect_excel(input_path: str, password: str | None, output_path: str, con
     return FileResult(path=output_path, status="unlocked", message=f"Excel unprotected → {output_path}")
 
 
-def unprotect_word(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
+def unprotect_word(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     ext = os.path.splitext(input_path)[1].lower()
-    if ext == ".doc" and not convert:
-        warnings.warn("Legacy .doc format: restrictions cannot be removed without --convert.")
     tmp_path = output_path + ".tmp.docx"
     try:
         was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_path)
@@ -390,7 +459,6 @@ def unprotect_word(input_path: str, password: str | None, output_path: str, conv
         if os.path.realpath(work_path) != os.path.realpath(output_path):
             shutil.copy2(work_path, output_path)
         if ext == ".docx" or (convert and ext == ".doc"):
-            from .unprotect import _strip_word_xml_protection  # assume similar function exists
             _strip_word_xml_protection(output_path)
             _remove_extra_protections_office(output_path, "word")
         if convert and ext == ".doc":
@@ -402,10 +470,8 @@ def unprotect_word(input_path: str, password: str | None, output_path: str, conv
     return FileResult(path=output_path, status="unlocked", message=f"Word unprotected → {output_path}")
 
 
-def unprotect_powerpoint(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
+def unprotect_powerpoint(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     ext = os.path.splitext(input_path)[1].lower()
-    if ext == ".ppt" and not convert:
-        warnings.warn("Legacy .ppt format: restrictions cannot be removed without --convert.")
     tmp_path = output_path + ".tmp.pptx"
     try:
         was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_path)
@@ -413,7 +479,6 @@ def unprotect_powerpoint(input_path: str, password: str | None, output_path: str
         if os.path.realpath(work_path) != os.path.realpath(output_path):
             shutil.copy2(work_path, output_path)
         if ext == ".pptx" or (convert and ext == ".ppt"):
-            from .unprotect import _strip_pptx_protections
             _strip_pptx_protections(output_path)
             _remove_extra_protections_office(output_path, "powerpoint")
         if convert and ext == ".ppt":
@@ -425,16 +490,15 @@ def unprotect_powerpoint(input_path: str, password: str | None, output_path: str
     return FileResult(path=output_path, status="unlocked", message=f"PowerPoint unprotected → {output_path}")
 
 
-# Legacy binary handlers (no XML stripping)
-def unprotect_doc(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
+def unprotect_doc(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     return unprotect_word(input_path, password, output_path, convert)
 
 
-def unprotect_xls(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
+def unprotect_xls(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     return unprotect_excel(input_path, password, output_path, convert)
 
 
-def unprotect_ppt(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
+def unprotect_ppt(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     return unprotect_powerpoint(input_path, password, output_path, convert)
 
 
@@ -454,7 +518,7 @@ SUPPORTED: dict[str, tuple[str, Callable]] = {
 
 
 # ---------------------------------------------------------------------------
-# Public library API (extended with convert flag)
+# Public library API
 # ---------------------------------------------------------------------------
 def unprotect_file(
     input_path: str,
@@ -484,12 +548,11 @@ def unprotect_file(
         _make_backup(input_path)
 
     log.debug("Processing %s: %s → %s", label, input_path, resolved_output)
-    # Pass convert flag to handler (all handlers now accept it)
     return handler(input_path, password, resolved_output, convert=convert)
 
 
 # ---------------------------------------------------------------------------
-# Password helpers (unchanged)
+# Password helpers
 # ---------------------------------------------------------------------------
 def _load_password_file(path: str) -> str:
     with open(path, "r") as f:
@@ -535,7 +598,7 @@ def _try_password_list(
 
 
 # ---------------------------------------------------------------------------
-# CLI entry point with parallel processing
+# Parallel worker and CLI entry point
 # ---------------------------------------------------------------------------
 def _expand_paths(patterns: list[str], recursive: bool) -> list[str]:
     paths = []
@@ -560,7 +623,7 @@ def _process_one(args_tuple):
     path, cli_args, password, convert = args_tuple
     # Recreate logger for worker (avoid duplicate handlers)
     worker_log = logging.getLogger(f"unprotect.{os.getpid()}")
-    worker_log.setLevel(logging.WARNING)  # silence per-worker logs
+    worker_log.setLevel(logging.WARNING)
     try:
         if cli_args.check:
             result = check_file(path, password)
@@ -686,7 +749,6 @@ Examples:
                         for f in futures:
                             f.cancel()
                         break
-        # Restore original order for output
         ordered = {res.path: res for res in results}
         results = [ordered[p] for p in input_paths if p in ordered]
     else:
@@ -727,7 +789,6 @@ Examples:
                 if args.fail_fast:
                     break
 
-    # Output results
     json_results = []
     counts = {"unlocked": 0, "open": 0, "skipped": 0, "failed": 0}
     exit_code = 0

--- a/unprotect.py
+++ b/unprotect.py
@@ -396,7 +396,7 @@ def _print_check_result(result: FileResult, use_json: bool, json_accumulator: li
 def unprotect_pdf(input_path: str, password: str | None, output_path: str, **kwargs) -> FileResult:
     try:
         from pypdf import PdfReader, PdfWriter
-        from pypdf.generic import ArrayObject
+        from pypdf.generic import ArrayObject, NameObject
     except ImportError:
         raise UnprotectError("Missing dependency: pip install pypdf")
 
@@ -454,7 +454,7 @@ def unprotect_pdf(input_path: str, password: str | None, output_path: str, **kwa
                 ]
             )
 
-            page["/Annots"] = filtered_annots
+            page[NameObject("/Annots")] = filtered_annots
 
             log.debug("  Removed redaction annotations")
 
@@ -788,7 +788,7 @@ Examples:
                     res = future.result()
                     results.append(res)
                 except Exception as e:
-                    results.append(FileResult(path=futures[future], status="failed", message=str(e)))
+                    results.append(FileResult(path=futures[future], status="failed", message=f"Error: {e}"))
                     if args.fail_fast:
                         for f in futures:
                             f.cancel()
@@ -825,7 +825,7 @@ Examples:
                     )
                 results.append(res)
             except UnprotectError as e:
-                results.append(FileResult(path=path, status="failed", message=str(e)))
+                results.append(FileResult(path=path, status="failed", message=f"Error: {e}"))
                 if args.fail_fast:
                     break
             except Exception as e:

--- a/unprotect.py
+++ b/unprotect.py
@@ -18,7 +18,6 @@ import sys
 import zipfile
 import argparse
 import subprocess
-import warnings
 from dataclasses import dataclass, field
 from typing import Callable
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -160,10 +159,14 @@ def _convert_with_libreoffice(input_path: str, output_path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# XML stripping helpers (previously imported – now defined here)
+# XML stripping helpers
 # ---------------------------------------------------------------------------
 def _strip_excel_xml_protection(xlsx_path: str):
-    import lxml.etree as etree
+    try:
+        import lxml.etree as etree
+    except ImportError:
+        log.warning("lxml not installed, cannot strip Excel XML protections")
+        return
     with zipfile.ZipFile(xlsx_path, "r") as z:
         names = z.namelist()
         wb_name = next((n for n in names if n.endswith("workbook.xml")), None)
@@ -197,7 +200,11 @@ def _strip_excel_xml_protection(xlsx_path: str):
 
 
 def _strip_word_xml_protection(docx_path: str):
-    import lxml.etree as etree
+    try:
+        import lxml.etree as etree
+    except ImportError:
+        log.warning("lxml not installed, cannot strip Word XML protections")
+        return
     with zipfile.ZipFile(docx_path, "r") as z:
         settings_name = next((n for n in z.namelist() if n.endswith("settings.xml")), None)
         if settings_name is None:
@@ -217,7 +224,11 @@ def _strip_word_xml_protection(docx_path: str):
 
 
 def _strip_pptx_protections(pptx_path: str):
-    import lxml.etree as etree
+    try:
+        import lxml.etree as etree
+    except ImportError:
+        log.warning("lxml not installed, cannot strip PowerPoint XML protections")
+        return
     with zipfile.ZipFile(pptx_path, "r") as z:
         names = z.namelist()
         prs_name = next((n for n in names if n.endswith("presentation.xml")), None)
@@ -262,7 +273,6 @@ def _strip_pptx_protections(pptx_path: str):
 
 def _remove_extra_protections_office(zip_path: str, file_type: str):
     """Remove digital signatures, etc."""
-    # Delete signature parts
     with zipfile.ZipFile(zip_path, "r") as z:
         names = z.namelist()
         sig_entries = [n for n in names if "_xmlsignatures" in n or n.endswith("signatures.xml")]
@@ -277,9 +287,13 @@ def _remove_extra_protections_office(zip_path: str, file_type: str):
 def _detect_xml_layers(input_path: str, ext: str) -> list[str]:
     layers = []
     try:
+        import lxml.etree as etree
+    except ImportError:
+        return layers  # cannot detect without lxml
+
+    try:
         with zipfile.ZipFile(input_path, "r") as z:
             names = z.namelist()
-            import lxml.etree as etree
 
             if ext in (".xlsx", ".xlsm"):
                 ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
@@ -391,7 +405,7 @@ def _print_check_result(result: FileResult, use_json: bool, json_accumulator: li
 
 
 # ---------------------------------------------------------------------------
-# Unprotect implementations (enhanced)
+# Unprotect implementations (enhanced & fixed)
 # ---------------------------------------------------------------------------
 def unprotect_pdf(input_path: str, password: str | None, output_path: str, **kwargs) -> FileResult:
     try:
@@ -417,33 +431,8 @@ def unprotect_pdf(input_path: str, password: str | None, output_path: str, **kwa
             )
 
     writer = PdfWriter()
-    writer.clone_reader_document_root(reader)
 
-    # ------------------------------------------------------------------
-    # Remove JavaScript and form restrictions from WRITER root
-    # ------------------------------------------------------------------
-    root = writer._root_object
-
-    # Remove JavaScript
-    if "/Names" in root:
-        names = root["/Names"]
-
-        if "/JavaScript" in names:
-            del names["/JavaScript"]
-            log.debug("  Removed embedded JavaScript")
-
-        # Remove empty Names dictionary
-        if len(names) == 0:
-            del root["/Names"]
-
-    # Remove AcroForm restrictions/forms
-    if "/AcroForm" in root:
-        del root["/AcroForm"]
-        log.debug("  Removed AcroForm")
-
-    # ------------------------------------------------------------------
-    # Remove redaction annotations
-    # ------------------------------------------------------------------
+    # Add pages, removing redaction annotations on the fly
     for page in reader.pages:
         if "/Annots" in page:
             filtered_annots = ArrayObject(
@@ -453,16 +442,28 @@ def unprotect_pdf(input_path: str, password: str | None, output_path: str, **kwa
                     if annot.get("/Subtype") != "/Redact"
                 ]
             )
-
             page[NameObject("/Annots")] = filtered_annots
-
             log.debug("  Removed redaction annotations")
-
         writer.add_page(page)
 
-    # ------------------------------------------------------------------
+    # Remove JavaScript and form restrictions from writer root
+    root = writer._root_object
+
+    # Remove JavaScript
+    if "/Names" in root:
+        names = root["/Names"]
+        if "/JavaScript" in names:
+            del names["/JavaScript"]
+            log.debug("  Removed embedded JavaScript")
+        if len(names) == 0:
+            del root["/Names"]
+
+    # Remove AcroForm
+    if "/AcroForm" in root:
+        del root["/AcroForm"]
+        log.debug("  Removed AcroForm")
+
     # Write cleaned PDF
-    # ------------------------------------------------------------------
     with open(output_path, "wb") as f:
         writer.write(f)
 
@@ -473,67 +474,108 @@ def unprotect_pdf(input_path: str, password: str | None, output_path: str, **kwa
     )
 
 
+def _handle_office_common(
+    input_path: str,
+    password: str | None,
+    output_path: str,
+    convert: bool,
+    is_legacy: bool,
+    strip_func: Callable,
+    new_ext: str,
+    log_label: str,
+) -> FileResult:
+    """
+    Common logic for Excel, Word, PowerPoint.
+    - If legacy and convert: decrypt (if needed) -> convert -> strip -> move.
+    - If legacy and not convert: decrypt (if needed) -> copy (no stripping).
+    - If OpenXML: decrypt (if needed) -> copy -> strip.
+    """
+    ext = os.path.splitext(input_path)[1].lower()
+    tmp_decrypted = None
+    tmp_converted = None
+
+    try:
+        if is_legacy and convert:
+            # --- Legacy to OpenXML conversion ---
+            # Step 1: decrypt to a temporary legacy file (if encrypted)
+            tmp_legacy = output_path + ".legacy"
+            was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_legacy)
+            source_for_conversion = tmp_legacy if was_encrypted else input_path
+
+            # Step 2: convert to new format (OpenXML)
+            tmp_converted = output_path + ".tmp" + new_ext
+            _convert_with_libreoffice(source_for_conversion, tmp_converted)
+
+            # Step 3: strip XML protection from the converted file
+            strip_func(tmp_converted)
+            _remove_extra_protections_office(tmp_converted, log_label)
+
+            # Step 4: move to final output
+            shutil.move(tmp_converted, output_path)
+            log.info("  Converted %s → %s", ext, new_ext)
+
+            # Cleanup
+            if was_encrypted:
+                _cleanup(tmp_legacy)
+            return FileResult(path=output_path, status="unlocked", message=f"{log_label} unprotected & converted → {output_path}")
+
+        else:
+            # --- Legacy without conversion, or OpenXML ---
+            # Decrypt if needed
+            tmp_decrypted = output_path + ".tmp" + (new_ext if not is_legacy else ext)
+            was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_decrypted)
+            work_path = tmp_decrypted if was_encrypted else input_path
+
+            # Copy to output (avoid self-copy when in-place)
+            if os.path.realpath(work_path) != os.path.realpath(output_path):
+                shutil.copy2(work_path, output_path)
+
+            # Strip XML protection only for OpenXML files (not legacy binaries)
+            if not is_legacy:
+                strip_func(output_path)
+                _remove_extra_protections_office(output_path, log_label)
+
+            return FileResult(path=output_path, status="unlocked", message=f"{log_label} unprotected → {output_path}")
+
+    finally:
+        _cleanup(tmp_decrypted)
+        _cleanup(tmp_converted)
+
+
 def unprotect_excel(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     ext = os.path.splitext(input_path)[1].lower()
-    tmp_path = output_path + ".tmp.xlsx"
-    try:
-        was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_path)
-        work_path = tmp_path if was_encrypted else input_path
-        if os.path.realpath(work_path) != os.path.realpath(output_path):
-            shutil.copy2(work_path, output_path)
-        if ext in (".xlsx", ".xlsm") or (convert and ext == ".xls"):
-            _strip_excel_xml_protection(output_path)
-            _remove_extra_protections_office(output_path, "excel")
-        if convert and ext == ".xls":
-            converted_path = os.path.splitext(output_path)[0] + ".xlsx"
-            _convert_with_libreoffice(output_path, converted_path)
-            os.replace(converted_path, output_path)
-            log.info("  Converted .xls → .xlsx")
-    finally:
-        _cleanup(tmp_path)
-    return FileResult(path=output_path, status="unlocked", message=f"Excel unprotected → {output_path}")
+    return _handle_office_common(
+        input_path, password, output_path, convert,
+        is_legacy=(ext == ".xls"),
+        strip_func=_strip_excel_xml_protection,
+        new_ext=".xlsx",
+        log_label="Excel"
+    )
 
 
 def unprotect_word(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     ext = os.path.splitext(input_path)[1].lower()
-    tmp_path = output_path + ".tmp.docx"
-    try:
-        was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_path)
-        work_path = tmp_path if was_encrypted else input_path
-        if os.path.realpath(work_path) != os.path.realpath(output_path):
-            shutil.copy2(work_path, output_path)
-        if ext == ".docx" or (convert and ext == ".doc"):
-            _strip_word_xml_protection(output_path)
-            _remove_extra_protections_office(output_path, "word")
-        if convert and ext == ".doc":
-            converted_path = os.path.splitext(output_path)[0] + ".docx"
-            _convert_with_libreoffice(output_path, converted_path)
-            os.replace(converted_path, output_path)
-    finally:
-        _cleanup(tmp_path)
-    return FileResult(path=output_path, status="unlocked", message=f"Word unprotected → {output_path}")
+    return _handle_office_common(
+        input_path, password, output_path, convert,
+        is_legacy=(ext == ".doc"),
+        strip_func=_strip_word_xml_protection,
+        new_ext=".docx",
+        log_label="Word"
+    )
 
 
 def unprotect_powerpoint(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     ext = os.path.splitext(input_path)[1].lower()
-    tmp_path = output_path + ".tmp.pptx"
-    try:
-        was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_path)
-        work_path = tmp_path if was_encrypted else input_path
-        if os.path.realpath(work_path) != os.path.realpath(output_path):
-            shutil.copy2(work_path, output_path)
-        if ext == ".pptx" or (convert and ext == ".ppt"):
-            _strip_pptx_protections(output_path)
-            _remove_extra_protections_office(output_path, "powerpoint")
-        if convert and ext == ".ppt":
-            converted_path = os.path.splitext(output_path)[0] + ".pptx"
-            _convert_with_libreoffice(output_path, converted_path)
-            os.replace(converted_path, output_path)
-    finally:
-        _cleanup(tmp_path)
-    return FileResult(path=output_path, status="unlocked", message=f"PowerPoint unprotected → {output_path}")
+    return _handle_office_common(
+        input_path, password, output_path, convert,
+        is_legacy=(ext == ".ppt"),
+        strip_func=_strip_pptx_protections,
+        new_ext=".pptx",
+        log_label="PowerPoint"
+    )
 
 
+# Aliases for legacy formats (they just reuse the above logic with convert flag)
 def unprotect_doc(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     return unprotect_word(input_path, password, output_path, convert)
 

--- a/unprotect.py
+++ b/unprotect.py
@@ -41,6 +41,7 @@ class FileResult:
     status: str                      # "unlocked" | "open" | "protected" | "failed" | "skipped"
     message: str = ""
     layers: list[str] = field(default_factory=list)
+    error_code: int = 0              # optional, for failure details
 
 
 # ---------------------------------------------------------------------------
@@ -64,7 +65,7 @@ def _msoffcrypto_decrypt(input_path: str, password: str, tmp_path: str) -> bool:
             return False
         if not password:
             raise UnprotectError(
-                "File is encrypted but no password provided.", code=2
+                "File is encrypted but no password provided.", code=1
             )
         try:
             office_file.load_key(password=password)
@@ -418,17 +419,15 @@ def unprotect_pdf(input_path: str, password: str | None, output_path: str, **kwa
 
     # Handle encrypted PDFs
     if reader.is_encrypted:
-        success = reader.decrypt(password or "")
-
-        # Retry empty password for owner-only encryption
-        if success == 0 and password:
-            success = reader.decrypt("")
-
+        # First try empty password (owner-only PDFs)
+        success = reader.decrypt("")
         if success == 0:
-            raise UnprotectError(
-                "Wrong password (or file uses unsupported encryption)",
-                code=2,
-            )
+            # Empty didn't work -> need a password
+            if not password:
+                raise UnprotectError("File is encrypted but no password provided.", code=1)
+            success = reader.decrypt(password)
+            if success == 0:
+                raise UnprotectError("Wrong password.", code=2)
 
     writer = PdfWriter()
 
@@ -575,7 +574,7 @@ def unprotect_powerpoint(input_path: str, password: str | None, output_path: str
     )
 
 
-# Aliases for legacy formats (they just reuse the above logic with convert flag)
+# Aliases for legacy formats
 def unprotect_doc(input_path: str, password: str | None, output_path: str, convert: bool = False, **kwargs) -> FileResult:
     return unprotect_word(input_path, password, output_path, convert)
 
@@ -589,7 +588,7 @@ def unprotect_ppt(input_path: str, password: str | None, output_path: str, conve
 
 
 # ---------------------------------------------------------------------------
-# Supported format registry (extended)
+# Supported format registry
 # ---------------------------------------------------------------------------
 SUPPORTED: dict[str, tuple[str, Callable]] = {
     ".pdf":  ("PDF",        unprotect_pdf),
@@ -739,9 +738,9 @@ def _process_one(args_tuple):
             )
             return result
     except UnprotectError as e:
-        return FileResult(path=path, status="failed", message=str(e))
+        return FileResult(path=path, status="failed", message=str(e), error_code=e.code)
     except Exception as e:
-        return FileResult(path=path, status="failed", message=f"Unexpected: {e}")
+        return FileResult(path=path, status="failed", message=f"Unexpected: {e}", error_code=1)
 
 
 def main(argv: list[str] | None = None):
@@ -830,7 +829,7 @@ Examples:
                     res = future.result()
                     results.append(res)
                 except Exception as e:
-                    results.append(FileResult(path=futures[future], status="failed", message=f"Error: {e}"))
+                    results.append(FileResult(path=futures[future], status="failed", message=f"Error: {e}", error_code=1))
                     if args.fail_fast:
                         for f in futures:
                             f.cancel()
@@ -867,11 +866,16 @@ Examples:
                     )
                 results.append(res)
             except UnprotectError as e:
-                results.append(FileResult(path=path, status="failed", message=f"Error: {e}"))
-                if args.fail_fast:
-                    break
+                # For single file, exit with the specific error code
+                if len(input_paths) == 1:
+                    log.error(str(e))
+                    sys.exit(e.code)
+                else:
+                    results.append(FileResult(path=path, status="failed", message=f"Error: {e}", error_code=e.code))
+                    if args.fail_fast:
+                        break
             except Exception as e:
-                results.append(FileResult(path=path, status="failed", message=f"Unexpected: {e}"))
+                results.append(FileResult(path=path, status="failed", message=f"Unexpected: {e}", error_code=1))
                 if args.fail_fast:
                     break
 
@@ -887,8 +891,9 @@ Examples:
             else:
                 log.info("%s", res.message)
         counts[res.status if res.status in counts else "failed"] += 1
+        # If any failure, use the highest error code among failures (or just 1)
         if res.status == "failed":
-            exit_code = 1
+            exit_code = max(exit_code, res.error_code) if res.error_code else 1
 
     if args.json_output:
         print(json.dumps(json_results, indent=2))

--- a/unprotect.py
+++ b/unprotect.py
@@ -17,15 +17,14 @@ import shutil
 import sys
 import zipfile
 import argparse
+import subprocess
+import warnings
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import Callable, List, Optional
+from concurrent.futures import ProcessPoolExecutor, as_completed
 
 # ---------------------------------------------------------------------------
 # Logging setup
-# ---------------------------------------------------------------------------
-# Two loggers:
-#   log        — user-facing messages (INFO = normal, DEBUG = --verbose)
-#   error_log  — always printed unless a caller suppresses it
 # ---------------------------------------------------------------------------
 log = logging.getLogger("unprotect")
 _handler = logging.StreamHandler(sys.stdout)
@@ -35,33 +34,30 @@ log.setLevel(logging.INFO)
 
 
 # ---------------------------------------------------------------------------
-# Public result type (enables library use)
+# Public result type
 # ---------------------------------------------------------------------------
 @dataclass
 class FileResult:
     path: str
     status: str                      # "unlocked" | "open" | "protected" | "failed" | "skipped"
     message: str = ""
-    layers: list[str] = field(default_factory=list)   # for --check / --json
+    layers: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
-# Internal helpers — no sys.exit() so they're library-safe
+# Internal helpers
 # ---------------------------------------------------------------------------
-
 class UnprotectError(Exception):
-    """Raised instead of sys.exit() so library callers can catch it."""
     def __init__(self, message: str, code: int = 1):
         super().__init__(message)
         self.code = code
 
 
 def _msoffcrypto_decrypt(input_path: str, password: str, tmp_path: str) -> bool:
-    """Decrypt an Office file using msoffcrypto. Returns True if it was encrypted."""
     try:
         import msoffcrypto
     except ImportError:
-        raise UnprotectError("Missing dependency! Please run: pip install msoffcrypto-tool")
+        raise UnprotectError("Missing dependency: pip install msoffcrypto-tool")
 
     with open(input_path, "rb") as f:
         office_file = msoffcrypto.OfficeFile(f)
@@ -69,16 +65,14 @@ def _msoffcrypto_decrypt(input_path: str, password: str, tmp_path: str) -> bool:
             return False
         if not password:
             raise UnprotectError(
-                "File is encrypted but no password was provided. "
-                "Use --password, --password-file, or supply one interactively.",
-                code=2,
+                "File is encrypted but no password provided.", code=2
             )
         try:
             office_file.load_key(password=password)
             with open(tmp_path, "wb") as out:
                 office_file.decrypt(out)
         except Exception as e:
-            raise UnprotectError(f"Couldn't decrypt file — {e}", code=2)
+            raise UnprotectError(f"Decryption failed: {e}", code=2)
     return True
 
 
@@ -109,6 +103,7 @@ def _resolve_output(
     output_arg: str | None,
     in_place: bool,
     output_dir: str | None,
+    convert: bool = False,
 ) -> str:
     if in_place:
         return input_path
@@ -116,11 +111,15 @@ def _resolve_output(
         return output_arg
     base = os.path.basename(input_path)
     name, ext = os.path.splitext(base)
+    if convert:
+        # Change extension to modern format
+        new_ext = {'.doc': '.docx', '.xls': '.xlsx', '.ppt': '.pptx'}.get(ext, ext)
+        base = name + new_ext
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
-        return os.path.join(output_dir, f"unlocked_{name}{ext}")
+        return os.path.join(output_dir, f"unlocked_{base}" if not convert else base)
     directory = os.path.dirname(input_path) or "."
-    return os.path.join(directory, f"unlocked_{name}{ext}")
+    return os.path.join(directory, f"unlocked_{base}" if not convert else base)
 
 
 def _check_collision(input_path: str, output_path: str, in_place: bool):
@@ -128,8 +127,7 @@ def _check_collision(input_path: str, output_path: str, in_place: bool):
         return
     if os.path.realpath(input_path) == os.path.realpath(output_path):
         raise UnprotectError(
-            "Input and output paths resolve to the same file. "
-            "Use --in-place to overwrite, or choose a different --output path."
+            "Input and output resolve to same file. Use --in-place to overwrite."
         )
 
 
@@ -140,25 +138,49 @@ def _make_backup(path: str) -> str:
     return backup
 
 
-# ---------------------------------------------------------------------------
-# Protection detection helpers
-# ---------------------------------------------------------------------------
+def _convert_with_libreoffice(input_path: str, output_path: str) -> None:
+    """Convert file using LibreOffice (--convert)."""
+    if not shutil.which("libreoffice"):
+        raise UnprotectError(
+            "libreoffice not found in PATH. Install LibreOffice to use --convert."
+        )
+    out_dir = os.path.dirname(output_path) or "."
+    out_ext = os.path.splitext(output_path)[1][1:]  # without dot
+    cmd = [
+        "libreoffice", "--headless", "--convert-to", out_ext,
+        "--outdir", out_dir, input_path
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        # LibreOffice creates file with original basename + new extension
+        converted_name = os.path.basename(input_path)
+        name_no_ext = os.path.splitext(converted_name)[0]
+        expected = os.path.join(out_dir, f"{name_no_ext}.{out_ext}")
+        if os.path.exists(expected) and expected != output_path:
+            shutil.move(expected, output_path)
+    except subprocess.CalledProcessError as e:
+        raise UnprotectError(f"Conversion failed: {e.stderr}")
 
+
+# ---------------------------------------------------------------------------
+# Protection detection (extended)
+# ---------------------------------------------------------------------------
 def _detect_xml_layers(input_path: str, ext: str) -> list[str]:
-    """Return a list of protection layer names found inside the zip."""
-    layers: list[str] = []
+    layers = []
     try:
         with zipfile.ZipFile(input_path, "r") as z:
             names = z.namelist()
-            import lxml.etree as etree
+            import lxml.etree as etree # type: ignore
 
             if ext in (".xlsx", ".xlsm"):
                 ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
                 wb_name = next((n for n in names if n.endswith("workbook.xml")), None)
                 if wb_name:
                     root = etree.fromstring(z.read(wb_name))
-                    if root.find(f"{{{ns}}}workbookProtection") is not None:
-                        layers.append("workbook structure")
+                    wb_prot = root.find(f"{{{ns}}}workbookProtection")
+                    if wb_prot is not None:
+                        if wb_prot.get("lockStructure") == "1":
+                            layers.append("workbook structure locked")
                 for n in names:
                     if n.startswith("xl/worksheets/sheet") and n.endswith(".xml"):
                         root = etree.fromstring(z.read(n))
@@ -170,7 +192,7 @@ def _detect_xml_layers(input_path: str, ext: str) -> list[str]:
                 settings_name = next((n for n in names if n.endswith("settings.xml")), None)
                 if settings_name:
                     root = etree.fromstring(z.read(settings_name))
-                    for tag in ("documentProtection", "writeProtection"):
+                    for tag in ("documentProtection", "writeProtection", "readOnlyRecommended"):
                         if root.find(f"{{{ns}}}{tag}") is not None:
                             layers.append(tag)
 
@@ -182,19 +204,19 @@ def _detect_xml_layers(input_path: str, ext: str) -> list[str]:
                     for tag in ("modifyVerifier", "writeProtection"):
                         if root.find(f"{{{ns}}}{tag}") is not None:
                             layers.append(tag)
-    except Exception as e:
-        log.debug("  Could not inspect XML layers: %s", e)
+
+            # Digital signatures detection
+            if any("signature" in name.lower() for name in names):
+                layers.append("digital signature")
+    except Exception:
+        pass
     return layers
 
 
 def check_file(input_path: str, password: str | None = None) -> FileResult:
-    """
-    Public API: inspect a file and return a FileResult describing its protection state.
-    Does not modify any file.
-    """
     ext = os.path.splitext(input_path)[1].lower()
 
-    if ext in (".xlsx", ".xlsm", ".docx", ".pptx"):
+    if ext in (".xlsx", ".xlsm", ".docx", ".pptx", ".doc", ".xls", ".ppt"):
         try:
             import msoffcrypto
             with open(input_path, "rb") as f:
@@ -209,40 +231,36 @@ def check_file(input_path: str, password: str | None = None) -> FileResult:
             return FileResult(
                 path=input_path,
                 status="protected",
-                message="file-level password required to open",
+                message="file-level encryption",
                 layers=["file encryption"],
             )
-        layers = _detect_xml_layers(input_path, ext)
-        if layers:
-            return FileResult(
-                path=input_path,
-                status="protected",
-                message=", ".join(layers),
-                layers=layers,
-            )
+        if ext in (".xlsx", ".xlsm", ".docx", ".pptx"):
+            layers = _detect_xml_layers(input_path, ext)
+            if layers:
+                return FileResult(
+                    path=input_path,
+                    status="protected",
+                    message=", ".join(layers),
+                    layers=layers,
+                )
         return FileResult(path=input_path, status="open", message="no protection detected")
 
     elif ext == ".pdf":
         try:
-            from pypdf import PdfReader
-            r = PdfReader(input_path)
-            if r.is_encrypted:
+            from pypdf import PdfReader # type: ignore
+            reader = PdfReader(input_path)
+            if reader.is_encrypted:
                 return FileResult(
                     path=input_path,
                     status="protected",
-                    message="PDF open password set",
+                    message="PDF encryption (open or owner password)",
                     layers=["PDF encryption"],
                 )
-            return FileResult(path=input_path, status="open", message="no PDF encryption detected")
+            return FileResult(path=input_path, status="open", message="no PDF encryption")
         except ImportError:
-            return FileResult(path=input_path, status="failed", message="Missing dependency: pip install pypdf")
+            return FileResult(path=input_path, status="failed", message="pip install pypdf")
 
-    else:
-        return FileResult(
-            path=input_path,
-            status="failed",
-            message=f"unsupported extension '{ext}'",
-        )
+    return FileResult(path=input_path, status="failed", message=f"unsupported extension '{ext}'")
 
 
 def _print_check_result(result: FileResult, use_json: bool, json_accumulator: list | None):
@@ -255,7 +273,6 @@ def _print_check_result(result: FileResult, use_json: bool, json_accumulator: li
                 "message": result.message,
             })
         return
-
     label_map = {
         "protected": "[PROTECTED]",
         "open":      "[OPEN]     ",
@@ -266,203 +283,179 @@ def _print_check_result(result: FileResult, use_json: bool, json_accumulator: li
 
 
 # ---------------------------------------------------------------------------
-# Unprotect implementations
+# Unprotect implementations (enhanced)
 # ---------------------------------------------------------------------------
-
 def unprotect_pdf(input_path: str, password: str | None, output_path: str) -> FileResult:
     try:
-        from pypdf import PdfReader, PdfWriter
+        from pypdf import PdfReader, PdfWriter # type: ignore
     except ImportError:
-        raise UnprotectError("Missing dependency! Please run: pip install pypdf")
+        raise UnprotectError("Missing dependency: pip install pypdf")
 
     reader = PdfReader(input_path)
     if reader.is_encrypted:
-        result = reader.decrypt(password or "")
-        if result == 0:
-            if password:
-                raise UnprotectError("Wrong password!", code=2)
-            else:
-                raise UnprotectError("PDF is encrypted and requires a password. Use --password.", code=1)
+        # Try given password; if fails, try empty for owner password
+        success = reader.decrypt(password or "")
+        if success == 0 and password:
+            # Maybe it's owner password? Try empty string (strips permissions)
+            success = reader.decrypt("")
+        if success == 0:
+            raise UnprotectError("Wrong password (or file uses unsupported encryption)", code=2)
 
     writer = PdfWriter()
+    # Copy pages and metadata (preserve everything except encryption)
+    writer.clone_reader_document_root(reader)
+    # Remove JavaScript actions
+    if "/Names" in reader.trailer.get("/Root", {}):
+        root = reader.trailer["/Root"]
+        if "/Names" in root and "/JavaScript" in root["/Names"]:
+            del root["/Names"]["/JavaScript"]
+    # Remove redaction annotations by not copying them (they are in pages)
+    # Remove form restrictions: delete /AcroForm or set /NeedAppearances
+    if "/AcroForm" in reader.trailer.get("/Root", {}):
+        del reader.trailer["/Root"]["/AcroForm"]
+
     for page in reader.pages:
+        # Optionally remove redaction annotations from page
+        if "/Annots" in page:
+            page["/Annots"] = [a for a in page["/Annots"] if a.get("/Subtype") != "/Redact"]
         writer.add_page(page)
+
     with open(output_path, "wb") as f:
         writer.write(f)
 
-    log.debug("  PDF pages copied, encryption stripped")
-    return FileResult(path=output_path, status="unlocked", message=f"PDF unprotected → {output_path}")
+    return FileResult(path=output_path, status="unlocked", message=f"PDF cleaned → {output_path}")
 
 
-def _strip_excel_xml_protection(xlsx_path: str):
-    import lxml.etree as etree
-
-    with zipfile.ZipFile(xlsx_path, "r") as z:
+def _remove_extra_protections_office(zip_path: str, file_type: str):
+    """Remove digital signatures, read-only recommended, etc. from OpenXML."""
+    import lxml.etree as etree # type: ignore
+    # Remove signature parts
+    with zipfile.ZipFile(zip_path, "r") as z:
         names = z.namelist()
-        wb_name = next((n for n in names if n.endswith("workbook.xml")), None)
-        wb_xml = z.read(wb_name) if wb_name else None
-        sheet_names = [n for n in names
-                       if n.startswith("xl/worksheets/sheet") and n.endswith(".xml")]
+        sig_entries = [n for n in names if "_xmlsignatures" in n or n.endswith("signatures.xml")]
+    for entry in sig_entries:
+        _rewrite_zip(zip_path, entry, b"")  # empty content effectively deletes
+        log.debug("  Removed signature entry: %s", entry)
 
-    if wb_name and wb_xml is not None:
-        wb_root = etree.fromstring(wb_xml)
-        ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-        removed = [el for el in wb_root.findall(f"{{{ns}}}workbookProtection")]
-        for el in removed:
-            wb_root.remove(el)
-            log.debug("  Removed workbookProtection from %s", wb_name)
-        if removed:
-            new_xml = etree.tostring(wb_root, xml_declaration=True, encoding="UTF-8", standalone=True)
-            _rewrite_zip(xlsx_path, wb_name, new_xml)
+    if file_type == "word":
+        # Remove readOnlyRecommended from settings.xml
+        with zipfile.ZipFile(zip_path, "r") as z:
+            settings_name = next((n for n in names if n.endswith("settings.xml")), None)
+            if settings_name:
+                xml = z.read(settings_name)
+                root = etree.fromstring(xml)
+                ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                for ro in root.findall(f"{{{ns}}}readOnlyRecommended"):
+                    ro.getparent().remove(ro)
+                    log.debug("  Removed readOnlyRecommended")
+                new_xml = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
+                _rewrite_zip(zip_path, settings_name, new_xml)
 
-    for sheet_name in sheet_names:
-        with zipfile.ZipFile(xlsx_path, "r") as z:
-            sheet_xml = z.read(sheet_name)
-        root = etree.fromstring(sheet_xml)
-        ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-        removed = [el for el in root.findall(f"{{{ns}}}sheetProtection")]
-        for el in removed:
-            root.remove(el)
-            log.debug("  Removed sheetProtection from %s", sheet_name)
-        if removed:
-            new_xml = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
-            _rewrite_zip(xlsx_path, sheet_name, new_xml)
+    # Add similar for Excel (lockStructure already handled in _strip_excel_xml_protection)
 
 
-def unprotect_excel(input_path: str, password: str | None, output_path: str) -> FileResult:
+def unprotect_excel(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
     ext = os.path.splitext(input_path)[1].lower()
-    if ext == ".xls":
-        raise UnprotectError("Legacy .xls format is not supported.")
-
+    if ext == ".xls" and not convert:
+        warnings.warn("Legacy .xls format: restrictions cannot be removed without --convert. Only decryption will be performed.")
     tmp_path = output_path + ".tmp.xlsx"
     try:
         was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_path)
         work_path = tmp_path if was_encrypted else input_path
         if os.path.realpath(work_path) != os.path.realpath(output_path):
             shutil.copy2(work_path, output_path)
-        _strip_excel_xml_protection(output_path)
+        if ext in (".xlsx", ".xlsm") or (convert and ext == ".xls"):
+            # Strip XML protections
+            from .unprotect import _strip_excel_xml_protection  # local import to avoid circular
+            _strip_excel_xml_protection(output_path)
+            _remove_extra_protections_office(output_path, "excel")
+        if convert and ext == ".xls":
+            converted_path = os.path.splitext(output_path)[0] + ".xlsx"
+            _convert_with_libreoffice(output_path, converted_path)
+            os.replace(converted_path, output_path)
+            log.info("  Converted .xls → .xlsx")
     finally:
         _cleanup(tmp_path)
-
     return FileResult(path=output_path, status="unlocked", message=f"Excel unprotected → {output_path}")
 
 
-def unprotect_word(input_path: str, password: str | None, output_path: str) -> FileResult:
+def unprotect_word(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
     ext = os.path.splitext(input_path)[1].lower()
-    if ext == ".doc":
-        raise UnprotectError("Legacy .doc format is not supported.")
-
+    if ext == ".doc" and not convert:
+        warnings.warn("Legacy .doc format: restrictions cannot be removed without --convert.")
     tmp_path = output_path + ".tmp.docx"
     try:
         was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_path)
         work_path = tmp_path if was_encrypted else input_path
         if os.path.realpath(work_path) != os.path.realpath(output_path):
             shutil.copy2(work_path, output_path)
-
-        import lxml.etree as etree
-        with zipfile.ZipFile(output_path, "r") as z:
-            settings_name = next((n for n in z.namelist() if n.endswith("settings.xml")), None)
-            if settings_name is None:
-                return FileResult(path=output_path, status="unlocked",
-                                  message=f"Word unprotected (no settings.xml) → {output_path}")
-            settings_xml = z.read(settings_name)
-
-        root = etree.fromstring(settings_xml)
-        ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
-        changed = False
-        for tag in ("documentProtection", "writeProtection"):
-            for el in root.findall(f"{{{ns}}}{tag}"):
-                root.remove(el)
-                log.debug("  Removed %s from %s", tag, settings_name)
-                changed = True
-        if changed:
-            new_xml = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
-            _rewrite_zip(output_path, settings_name, new_xml)
+        if ext == ".docx" or (convert and ext == ".doc"):
+            from .unprotect import _strip_word_xml_protection  # assume similar function exists
+            _strip_word_xml_protection(output_path)
+            _remove_extra_protections_office(output_path, "word")
+        if convert and ext == ".doc":
+            converted_path = os.path.splitext(output_path)[0] + ".docx"
+            _convert_with_libreoffice(output_path, converted_path)
+            os.replace(converted_path, output_path)
     finally:
         _cleanup(tmp_path)
-
     return FileResult(path=output_path, status="unlocked", message=f"Word unprotected → {output_path}")
 
 
-def unprotect_powerpoint(input_path: str, password: str | None, output_path: str) -> FileResult:
+def unprotect_powerpoint(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
     ext = os.path.splitext(input_path)[1].lower()
-    if ext == ".ppt":
-        raise UnprotectError("Legacy .ppt format is not supported.")
-
+    if ext == ".ppt" and not convert:
+        warnings.warn("Legacy .ppt format: restrictions cannot be removed without --convert.")
     tmp_path = output_path + ".tmp.pptx"
     try:
         was_encrypted = _msoffcrypto_decrypt(input_path, password or "", tmp_path)
         work_path = tmp_path if was_encrypted else input_path
         if os.path.realpath(work_path) != os.path.realpath(output_path):
             shutil.copy2(work_path, output_path)
-
-        import lxml.etree as etree
-        with zipfile.ZipFile(output_path, "r") as z:
-            names = z.namelist()
-            prs_name = next((n for n in names if n.endswith("presentation.xml")), None)
-            if prs_name is None:
-                return FileResult(path=output_path, status="unlocked",
-                                  message=f"PowerPoint unprotected (no presentation.xml) → {output_path}")
-            prs_xml = z.read(prs_name)
-
-        root = etree.fromstring(prs_xml)
-        ns_pml = "http://schemas.openxmlformats.org/presentationml/2006/main"
-        changed = False
-        for tag in ("modifyVerifier", "writeProtection"):
-            for el in root.findall(f"{{{ns_pml}}}{tag}"):
-                root.remove(el)
-                log.debug("  Removed %s from %s", tag, prs_name)
-                changed = True
-        if changed:
-            new_xml = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
-            _rewrite_zip(output_path, prs_name, new_xml)
-
-        with zipfile.ZipFile(output_path, "r") as z:
-            slide_names = [n for n in z.namelist()
-                           if n.startswith("ppt/slides/slide") and n.endswith(".xml")]
-        for slide_name in slide_names:
-            with zipfile.ZipFile(output_path, "r") as z:
-                slide_xml = z.read(slide_name)
-            slide_root = etree.fromstring(slide_xml)
-            mc_ns = "http://schemas.openxmlformats.org/markup-compatibility/2006"
-            slide_changed = False
-            for ac in slide_root.findall(f".//{{{mc_ns}}}AlternateContent"):
-                parent = ac.getparent()
-                if parent is not None:
-                    raw = etree.tostring(ac)
-                    if b"oleObj" in raw and b"locked" in raw:
-                        parent.remove(ac)
-                        log.debug("  Removed locked AlternateContent from %s", slide_name)
-                        slide_changed = True
-            if slide_changed:
-                new_slide_xml = etree.tostring(slide_root, xml_declaration=True,
-                                               encoding="UTF-8", standalone=True)
-                _rewrite_zip(output_path, slide_name, new_slide_xml)
+        if ext == ".pptx" or (convert and ext == ".ppt"):
+            from .unprotect import _strip_pptx_protections
+            _strip_pptx_protections(output_path)
+            _remove_extra_protections_office(output_path, "powerpoint")
+        if convert and ext == ".ppt":
+            converted_path = os.path.splitext(output_path)[0] + ".pptx"
+            _convert_with_libreoffice(output_path, converted_path)
+            os.replace(converted_path, output_path)
     finally:
         _cleanup(tmp_path)
-
     return FileResult(path=output_path, status="unlocked", message=f"PowerPoint unprotected → {output_path}")
 
 
+# Legacy binary handlers (no XML stripping)
+def unprotect_doc(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
+    return unprotect_word(input_path, password, output_path, convert)
+
+
+def unprotect_xls(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
+    return unprotect_excel(input_path, password, output_path, convert)
+
+
+def unprotect_ppt(input_path: str, password: str | None, output_path: str, convert: bool = False) -> FileResult:
+    return unprotect_powerpoint(input_path, password, output_path, convert)
+
+
 # ---------------------------------------------------------------------------
-# Supported format registry
+# Supported format registry (extended)
 # ---------------------------------------------------------------------------
 SUPPORTED: dict[str, tuple[str, Callable]] = {
     ".pdf":  ("PDF",        unprotect_pdf),
     ".xlsx": ("Excel",      unprotect_excel),
     ".xlsm": ("Excel",      unprotect_excel),
-    ".xls":  ("Excel",      unprotect_excel),
+    ".xls":  ("Excel (legacy)", unprotect_xls),
     ".docx": ("Word",       unprotect_word),
-    ".doc":  ("Word",       unprotect_word),
+    ".doc":  ("Word (legacy)",   unprotect_doc),
     ".pptx": ("PowerPoint", unprotect_powerpoint),
-    ".ppt":  ("PowerPoint", unprotect_powerpoint),
+    ".ppt":  ("PowerPoint (legacy)", unprotect_ppt),
 }
 
 
 # ---------------------------------------------------------------------------
-# Public library API
+# Public library API (extended with convert flag)
 # ---------------------------------------------------------------------------
-
 def unprotect_file(
     input_path: str,
     password: str | None = None,
@@ -471,56 +464,33 @@ def unprotect_file(
     output_dir: str | None = None,
     backup: bool = False,
     no_overwrite: bool = False,
+    convert: bool = False,
 ) -> FileResult:
-    """
-    Remove protection from a single file.
-
-    Parameters
-    ----------
-    input_path  : Path to the protected file.
-    password    : Open password, if any.
-    output_path : Explicit output path (single-file mode).
-    in_place    : Overwrite the original file.
-    output_dir  : Directory for output (batch-friendly).
-    backup      : Create a .bak copy before modifying (only with in_place).
-    no_overwrite: Skip if the output file already exists.
-
-    Returns
-    -------
-    FileResult with status "unlocked", "open", "skipped", or raises UnprotectError.
-    """
     if not os.path.exists(input_path):
         raise UnprotectError(f"File not found: {input_path}", code=4)
 
     ext = os.path.splitext(input_path)[1].lower()
     if ext not in SUPPORTED:
-        supported_list = ", ".join(SUPPORTED.keys())
-        raise UnprotectError(
-            f"Unsupported file type '{ext}'. Supported: {supported_list}", code=3
-        )
+        raise UnprotectError(f"Unsupported file type '{ext}'. Supported: {', '.join(SUPPORTED.keys())}", code=3)
 
     label, handler = SUPPORTED[ext]
-    resolved_output = _resolve_output(input_path, output_path, in_place, output_dir)
+    resolved_output = _resolve_output(input_path, output_path, in_place, output_dir, convert)
     _check_collision(input_path, resolved_output, in_place)
 
     if no_overwrite and os.path.exists(resolved_output):
-        return FileResult(
-            path=input_path,
-            status="skipped",
-            message=f"output already exists, skipping: {resolved_output}",
-        )
+        return FileResult(path=input_path, status="skipped", message=f"output exists: {resolved_output}")
 
     if backup and in_place and os.path.exists(input_path):
         _make_backup(input_path)
 
-    log.debug("Processing %s file: %s → %s", label, input_path, resolved_output)
-    return handler(input_path, password, resolved_output)
+    log.debug("Processing %s: %s → %s", label, input_path, resolved_output)
+    # Pass convert flag to handler (all handlers now accept it)
+    return handler(input_path, password, resolved_output, convert=convert)
 
 
 # ---------------------------------------------------------------------------
-# Password helpers
+# Password helpers (unchanged)
 # ---------------------------------------------------------------------------
-
 def _load_password_file(path: str) -> str:
     with open(path, "r") as f:
         line = f.readline().rstrip("\n")
@@ -537,11 +507,10 @@ def _try_password_list(
     output_dir: str | None,
     backup: bool,
     no_overwrite: bool,
+    convert: bool,
 ) -> FileResult:
-    """Try each line of wordlist_path as a password; return on first success."""
     with open(wordlist_path, "r", errors="replace") as f:
         passwords = [line.rstrip("\n") for line in f if line.strip()]
-
     log.info("Trying %d passwords from %s …", len(passwords), wordlist_path)
     for i, pwd in enumerate(passwords, 1):
         log.debug("  Attempt %d/%d: %s", i, len(passwords), pwd)
@@ -554,34 +523,30 @@ def _try_password_list(
                 output_dir=output_dir,
                 backup=backup,
                 no_overwrite=no_overwrite,
+                convert=convert,
             )
             log.info("  Password found: %s (attempt %d/%d)", pwd, i, len(passwords))
             return result
         except UnprotectError as e:
-            if e.code == 2:   # wrong password — keep trying
+            if e.code == 2:
                 continue
-            raise             # other errors bubble up
-
-    raise UnprotectError(
-        f"No password from '{wordlist_path}' worked ({len(passwords)} tried).", code=2
-    )
+            raise
+    raise UnprotectError(f"No password from '{wordlist_path}' worked ({len(passwords)} tried).", code=2)
 
 
 # ---------------------------------------------------------------------------
-# CLI entry point
+# CLI entry point with parallel processing
 # ---------------------------------------------------------------------------
-
 def _expand_paths(patterns: list[str], recursive: bool) -> list[str]:
-    paths: list[str] = []
+    paths = []
     for pattern in patterns:
         expanded = glob.glob(pattern, recursive=recursive)
         if expanded:
             paths.extend(expanded)
         else:
-            paths.append(pattern)  # keep as-is so "file not found" error fires naturally
-    # Deduplicate while preserving order
-    seen: set[str] = set()
-    result: list[str] = []
+            paths.append(pattern)
+    seen = set()
+    result = []
     for p in paths:
         rp = os.path.realpath(p)
         if rp not in seen:
@@ -590,72 +555,82 @@ def _expand_paths(patterns: list[str], recursive: bool) -> list[str]:
     return result
 
 
+def _process_one(args_tuple):
+    """Worker function for parallel execution."""
+    path, cli_args, password, convert = args_tuple
+    # Recreate logger for worker (avoid duplicate handlers)
+    worker_log = logging.getLogger(f"unprotect.{os.getpid()}")
+    worker_log.setLevel(logging.WARNING)  # silence per-worker logs
+    try:
+        if cli_args.check:
+            result = check_file(path, password)
+            return result
+        elif cli_args.password_list:
+            result = _try_password_list(
+                input_path=path,
+                wordlist_path=cli_args.password_list,
+                output_path=cli_args.output,
+                in_place=cli_args.in_place,
+                output_dir=cli_args.output_dir,
+                backup=cli_args.backup,
+                no_overwrite=cli_args.no_overwrite,
+                convert=convert,
+            )
+            return result
+        else:
+            result = unprotect_file(
+                input_path=path,
+                password=password,
+                output_path=cli_args.output,
+                in_place=cli_args.in_place,
+                output_dir=cli_args.output_dir,
+                backup=cli_args.backup,
+                no_overwrite=cli_args.no_overwrite,
+                convert=convert,
+            )
+            return result
+    except UnprotectError as e:
+        return FileResult(path=path, status="failed", message=str(e))
+    except Exception as e:
+        return FileResult(path=path, status="failed", message=f"Unexpected: {e}")
+
+
 def main(argv: list[str] | None = None):
     parser = argparse.ArgumentParser(
-        description="Remove password protection from PDF and Office files.",
+        description="Remove password protection from PDF and Office files (now with legacy formats, conversion, parallel processing).",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
   unprotect.py report.xlsx --password secret
-  unprotect.py "*.xlsx" --output-dir ./unlocked/ --quiet
-  unprotect.py "**/*.docx" --recursive --in-place --backup
-  unprotect.py report.xlsx --password-list words.txt
+  unprotect.py "*.xls" --convert --output-dir ./unlocked/
+  unprotect.py "**/*.doc" --recursive --in-place --backup --jobs 4
+  unprotect.py report.xlsx --password-list words.txt --convert
   unprotect.py *.pdf --check --json
 """,
     )
-
-    # Positional
-    parser.add_argument("files", nargs="+",
-                        help="Path(s) or glob pattern(s) to protected file(s)")
-
-    # Password options (mutually exclusive group)
+    parser.add_argument("files", nargs="+", help="Path(s) or glob pattern(s)")
     pw_group = parser.add_mutually_exclusive_group()
-    pw_group.add_argument("--password", "-p", default=None,
-                          help="Password to unlock the file")
-    pw_group.add_argument("--password-file", metavar="FILE",
-                          help="File containing the password (first line used)")
-    pw_group.add_argument("--password-list", metavar="WORDLIST",
-                          help="Try each line of WORDLIST as a password (brute-force)")
-
-    # Output options
+    pw_group.add_argument("--password", "-p", default=None)
+    pw_group.add_argument("--password-file", metavar="FILE")
+    pw_group.add_argument("--password-list", metavar="WORDLIST")
     out_group = parser.add_mutually_exclusive_group()
-    out_group.add_argument("--output", "-o", default=None,
-                           help="Output path (single-file mode only)")
-    out_group.add_argument("--in-place", action="store_true",
-                           help="Overwrite the original file(s)")
-    out_group.add_argument("--output-dir", metavar="DIR",
-                           help="Directory to write unlocked files into")
-
-    # Safety
-    parser.add_argument("--backup", action="store_true",
-                        help="Create a .bak copy before modifying (with --in-place)")
-    parser.add_argument("--no-overwrite", action="store_true",
-                        help="Skip files whose output path already exists")
-
-    # Check / dry-run
-    parser.add_argument("--check", "--dry-run", action="store_true",
-                        help="Inspect protection without modifying any file (alias: --dry-run)")
-    parser.add_argument("--json", dest="json_output", action="store_true",
-                        help="Emit machine-readable JSON for --check output")
-
-    # Directory walking
-    parser.add_argument("--recursive", "-r", action="store_true",
-                        help="Expand ** in glob patterns recursively")
-
-    # Error handling
-    parser.add_argument("--fail-fast", action="store_true",
-                        help="Stop immediately on the first error")
-
-    # Verbosity (mutually exclusive)
+    out_group.add_argument("--output", "-o", default=None)
+    out_group.add_argument("--in-place", action="store_true")
+    out_group.add_argument("--output-dir", metavar="DIR")
+    parser.add_argument("--backup", action="store_true")
+    parser.add_argument("--no-overwrite", action="store_true")
+    parser.add_argument("--check", "--dry-run", action="store_true")
+    parser.add_argument("--json", dest="json_output", action="store_true")
+    parser.add_argument("--recursive", "-r", action="store_true")
+    parser.add_argument("--fail-fast", action="store_true")
+    parser.add_argument("--convert", action="store_true", help="Convert legacy binary formats to OpenXML (requires LibreOffice)")
+    parser.add_argument("--jobs", "-j", type=int, default=1, help="Number of parallel workers (default: 1)")
     verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument("--verbose", "-v", action="store_true",
-                           help="Show detailed per-element info")
-    verbosity.add_argument("--quiet", "-q", action="store_true",
-                           help="Suppress all output except errors")
+    verbosity.add_argument("--verbose", "-v", action="store_true")
+    verbosity.add_argument("--quiet", "-q", action="store_true")
 
     args = parser.parse_args(argv)
 
-    # ---- Configure logging level ----------------------------------------
     if args.verbose:
         log.setLevel(logging.DEBUG)
     elif args.quiet:
@@ -663,16 +638,14 @@ Examples:
     else:
         log.setLevel(logging.INFO)
 
-    # ---- Mutual-exclusion guards -----------------------------------------
     if args.backup and not args.in_place:
         parser.error("--backup only makes sense with --in-place")
-
     if args.json_output and not args.check:
-        parser.error("--json only makes sense with --check / --dry-run")
+        parser.error("--json only with --check")
+    if args.convert and args.check:
+        parser.error("--convert cannot be used with --check (no conversion in dry-run)")
 
-    # ---- Resolve password ------------------------------------------------
-    password: str | None = args.password
-
+    password = args.password
     if args.password_file:
         try:
             password = _load_password_file(args.password_file)
@@ -680,23 +653,12 @@ Examples:
             log.error("Error reading --password-file: %s", e)
             sys.exit(1)
 
-    # (--password-list is handled per-file below; no global password needed)
-
-    # ---- Expand file patterns -------------------------------------------
     input_paths = _expand_paths(args.files, recursive=args.recursive)
 
     if args.output and len(input_paths) > 1:
-        parser.error("--output can only be used when processing a single file.")
+        parser.error("--output only for single file")
 
-    # ---- Interactive password prompt (TTY only) --------------------------
-    # Prompt once before the loop if we need a password and stdin is a TTY.
-    if (
-        not args.check
-        and not args.password_list
-        and password is None
-        and sys.stdin.isatty()
-        and len(input_paths) > 0
-    ):
+    if not args.check and not args.password_list and password is None and sys.stdin.isatty() and input_paths:
         try:
             prompted = getpass.getpass("Password (leave blank if none): ")
             if prompted:
@@ -705,78 +667,88 @@ Examples:
             print()
             sys.exit(130)
 
-    # ---- Main processing loop -------------------------------------------
-    json_results: list[dict] = []
+    # Parallel processing
+    if args.jobs > 1:
+        log.debug("Using %d parallel workers", args.jobs)
+        results = []
+        with ProcessPoolExecutor(max_workers=args.jobs) as executor:
+            futures = {
+                executor.submit(_process_one, (path, args, password, args.convert)): path
+                for path in input_paths
+            }
+            for future in as_completed(futures):
+                try:
+                    res = future.result()
+                    results.append(res)
+                except Exception as e:
+                    results.append(FileResult(path=futures[future], status="failed", message=str(e)))
+                    if args.fail_fast:
+                        for f in futures:
+                            f.cancel()
+                        break
+        # Restore original order for output
+        ordered = {res.path: res for res in results}
+        results = [ordered[p] for p in input_paths if p in ordered]
+    else:
+        results = []
+        for path in input_paths:
+            try:
+                if args.check:
+                    res = check_file(path, password)
+                elif args.password_list:
+                    res = _try_password_list(
+                        input_path=path,
+                        wordlist_path=args.password_list,
+                        output_path=args.output,
+                        in_place=args.in_place,
+                        output_dir=args.output_dir,
+                        backup=args.backup,
+                        no_overwrite=args.no_overwrite,
+                        convert=args.convert,
+                    )
+                else:
+                    res = unprotect_file(
+                        input_path=path,
+                        password=password,
+                        output_path=args.output,
+                        in_place=args.in_place,
+                        output_dir=args.output_dir,
+                        backup=args.backup,
+                        no_overwrite=args.no_overwrite,
+                        convert=args.convert,
+                    )
+                results.append(res)
+            except UnprotectError as e:
+                results.append(FileResult(path=path, status="failed", message=str(e)))
+                if args.fail_fast:
+                    break
+            except Exception as e:
+                results.append(FileResult(path=path, status="failed", message=f"Unexpected: {e}"))
+                if args.fail_fast:
+                    break
+
+    # Output results
+    json_results = []
     counts = {"unlocked": 0, "open": 0, "skipped": 0, "failed": 0}
     exit_code = 0
-
-    for path in input_paths:
-        try:
-            if args.check:
-                result = check_file(path, password)
-                _print_check_result(result, args.json_output, json_results)
-                counts[result.status if result.status in counts else "failed"] += 1
-
-            elif args.password_list:
-                result = _try_password_list(
-                    input_path=path,
-                    wordlist_path=args.password_list,
-                    output_path=args.output,
-                    in_place=args.in_place,
-                    output_dir=args.output_dir,
-                    backup=args.backup,
-                    no_overwrite=args.no_overwrite,
-                )
-                log.info("%s", result.message)
-                counts[result.status if result.status in counts else "failed"] += 1
-
+    for res in results:
+        if args.check:
+            _print_check_result(res, args.json_output, json_results if args.json_output else None)
+        else:
+            if res.status == "skipped":
+                log.info("Skipped: %s", res.message)
             else:
-                result = unprotect_file(
-                    input_path=path,
-                    password=password,
-                    output_path=args.output,
-                    in_place=args.in_place,
-                    output_dir=args.output_dir,
-                    backup=args.backup,
-                    no_overwrite=args.no_overwrite,
-                )
-                log.info("%s", result.message)
-                if result.status == "skipped":
-                    log.info("  Skipped: %s", result.message)
-                counts[result.status if result.status in counts else "failed"] += 1
-
-        except UnprotectError as e:
-            log.error("Error [%s]: %s", path, e)
-            counts["failed"] += 1
-            exit_code = e.code
-            if args.fail_fast:
-                log.error("--fail-fast: stopping after first error.")
-                break
-        except Exception as e:
-            log.error("Unexpected error [%s]: %s", path, e)
-            counts["failed"] += 1
+                log.info("%s", res.message)
+        counts[res.status if res.status in counts else "failed"] += 1
+        if res.status == "failed":
             exit_code = 1
-            if args.fail_fast:
-                log.error("--fail-fast: stopping after first error.")
-                break
 
-    # ---- JSON output (--check --json) -----------------------------------
     if args.json_output:
         print(json.dumps(json_results, indent=2))
 
-    # ---- Summary (batch jobs with >1 file) ------------------------------
     if len(input_paths) > 1 and not args.quiet:
-        parts: list[str] = []
-        if counts["unlocked"]:
-            parts.append(f"{counts['unlocked']} unlocked")
-        if counts["open"]:
-            parts.append(f"{counts['open']} already open")
-        if counts["skipped"]:
-            parts.append(f"{counts['skipped']} skipped (output exists)")
-        if counts["failed"]:
-            parts.append(f"{counts['failed']} failed")
-        if not args.json_output:
-            log.info("\nDone: %s", ", ".join(parts) if parts else "nothing processed")
+        parts = [f"{counts[k]} {k}" for k in ("unlocked", "open", "skipped", "failed") if counts[k]]
+        log.info("\nDone: %s", ", ".join(parts) if parts else "nothing processed")
 
     sys.exit(exit_code)
 

--- a/unprotect_gui.py
+++ b/unprotect_gui.py
@@ -3,9 +3,9 @@
 unprotect_gui.py — Full-featured GUI for unprotect.py
 All CLI features exposed: password/password-file/password-list, output/output-dir/in-place,
 backup, no-overwrite, fail-fast, check/dry-run, JSON export, glob/recursive input,
-verbose/quiet log, per-file status.
+verbose/quiet log, per-file status, plus new: parallel jobs (--jobs) and conversion (--convert).
 
-Requires:  pip install customtkinter pypdf msoffcrypto-tool lxml
+Requires:  pip install customtkinter pypdf msoffcrypto-tool lxml CTkSpinbox
 Place in the same directory as unprotect.py and run:  python unprotect_gui.py
 """
 
@@ -19,7 +19,8 @@ import sys
 import threading
 import time
 from pathlib import Path
-from tkinter import BooleanVar, StringVar, filedialog, messagebox
+from tkinter import BooleanVar, IntVar, StringVar, filedialog, messagebox
+from CTkSpinbox import CTkSpinbox
 import tkinter as tk
 
 try:
@@ -579,7 +580,7 @@ class OutputTab(ctk.CTkFrame):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Tab: Advanced
+# Tab: Advanced (updated with --jobs and --convert)
 # ─────────────────────────────────────────────────────────────────────────────
 
 class AdvancedTab(ctk.CTkFrame):
@@ -623,9 +624,41 @@ class AdvancedTab(ctk.CTkFrame):
                                text_color=TEXT, fg_color=ACCENT,
                                ).pack(side="left", padx=(0, 20))
 
+        # ── NEW: Parallel jobs ────────────────────────────────────────────
+        jobs_card = _card()
+        jobs_card.grid(row=2, column=0, sticky="ew", pady=(0, 8))
+        SectionLabel(jobs_card, text="PARALLEL PROCESSING").grid(
+            row=0, column=0, sticky="w", padx=12, pady=(8, 4))
+        frame_jobs = ctk.CTkFrame(jobs_card, fg_color="transparent")
+        frame_jobs.grid(row=1, column=0, sticky="w", padx=12, pady=(0, 10))
+        ctk.CTkLabel(frame_jobs, text="Workers:",
+                     font=ctk.CTkFont("Courier New", 11), text_color=TEXT).pack(side="left")
+        self._jobs_var = IntVar(value=1)
+        self._jobs_spin = CTkSpinbox(frame_jobs, start_value=1, min_value=1, max_value=16, step_value=1, variable=self._jobs_var, width=60, button_color=ACCENT, font=ctk.CTkFont("Courier New", 11), fg_color=CARD2, border_color=BORDER)
+        self._jobs_spin.pack(side="left", padx=(10, 0))
+        ctk.CTkLabel(frame_jobs, text="(1-16 workers – parallel processing not yet implemented in the GUI)", font=ctk.CTkFont("Courier New", 9), text_color=TEXT_DIM).pack(side="left", padx=(10, 0))
+
+        # ── NEW: Convert legacy formats (--convert) ────────────────────────
+        convert_card = _card()
+        convert_card.grid(row=3, column=0, sticky="ew", pady=(0, 8))
+        SectionLabel(convert_card, text="AUTOMATIC CONVERSION").grid(
+            row=0, column=0, sticky="w", padx=12, pady=(8, 4))
+        self._convert_var = BooleanVar()
+        ck = ctk.CTkCheckBox(convert_card,
+                             text="Convert legacy binary formats to OpenXML (--convert)",
+                             variable=self._convert_var,
+                             font=ctk.CTkFont("Courier New", 11),
+                             text_color=TEXT, fg_color=ACCENT)
+        ck.grid(row=1, column=0, sticky="w", padx=12, pady=(0, 4))
+        ctk.CTkLabel(convert_card,
+                     text="Requires LibreOffice installed and in PATH. Converts .doc→.docx, .xls→.xlsx, .ppt→.pptx.\n"
+                          "Warning: macros may be lost during conversion.",
+                     font=ctk.CTkFont("Courier New", 9), text_color=WARN,
+                     wraplength=700, justify="left").grid(row=2, column=0, sticky="w", padx=12, pady=(0, 10))
+
         # JSON export
         json_card = _card()
-        json_card.grid(row=2, column=0, sticky="ew", pady=(0, 8))
+        json_card.grid(row=4, column=0, sticky="ew", pady=(0, 8))
         SectionLabel(json_card,
                      text="JSON EXPORT  (Inspect/Check mode only -- mirrors --check --json)").grid(
             row=0, column=0, sticky="w", padx=12, pady=(8, 6))
@@ -649,17 +682,25 @@ class AdvancedTab(ctk.CTkFrame):
     def json_export(self) -> bool:
         return self._json_var.get()
 
+    @property
+    def jobs(self) -> int:
+        return self._jobs_var.get()
+
+    @property
+    def convert(self) -> bool:
+        return self._convert_var.get()
+
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Main Application
+# Main Application (with scrollable area)
 # ─────────────────────────────────────────────────────────────────────────────
 
 class UnprotectApp(ctk.CTk):
     def __init__(self):
         super().__init__()
         self.title("Unprotect")
-        self.geometry("860x820")
-        self.minsize(720, 640)
+        self.geometry("860x880")
+        self.minsize(720, 680)
         self.configure(fg_color=BG)
 
         self._q: queue.Queue = queue.Queue()
@@ -672,7 +713,7 @@ class UnprotectApp(ctk.CTk):
             self.log("unprotect.py not found in the same directory.", "warn")
             self.log("Place unprotect.py alongside this file and restart.", "warn")
 
-    # ── Layout ────────────────────────────────────────────────────────────
+    # ── Layout with scrollable area ───────────────────────────────────────
 
     def _build(self):
         # Header
@@ -686,10 +727,16 @@ class UnprotectApp(ctk.CTk):
                      font=ctk.CTkFont("Courier New", 9),
                      text_color=TEXT_DIM).pack(side="left", padx=4)
 
-        body = ctk.CTkFrame(self, fg_color="transparent")
-        body.pack(fill="both", expand=True, padx=14, pady=10)
+        # Main scrollable area
+        main_scroll = ctk.CTkScrollableFrame(self, fg_color="transparent",
+                                             scrollbar_button_color=BORDER,
+                                             scrollbar_button_hover_color=ACCENT)
+        main_scroll.pack(fill="both", expand=True, padx=14, pady=10)
+
+        # Place everything inside the scrollable frame
+        body = ctk.CTkFrame(main_scroll, fg_color="transparent")
+        body.pack(fill="both", expand=True)
         body.columnconfigure(0, weight=1)
-        body.rowconfigure(0, weight=1)
 
         # Tabview
         self._tabs = ctk.CTkTabview(
@@ -704,7 +751,7 @@ class UnprotectApp(ctk.CTk):
             border_width=1, border_color=BORDER,
             corner_radius=10,
         )
-        self._tabs.grid(row=0, column=0, sticky="nsew")
+        self._tabs.grid(row=0, column=0, sticky="ew", pady=(0, 6))
 
         for name in ("Files", "Password", "Output", "Advanced"):
             self._tabs.add(name)
@@ -830,6 +877,20 @@ class UnprotectApp(ctk.CTk):
                 "not with Unprotect.")
             return False
 
+        # Warn about conversion without LibreOffice (but don't block)
+        if not check_only and adv.convert:
+            import shutil
+            if not shutil.which("libreoffice"):
+                response = messagebox.askyesno(
+                    "LibreOffice missing",
+                    "Conversion requires LibreOffice to be installed and in PATH.\n"
+                    "Without it, conversion will fail.\n\n"
+                    "Do you want to continue anyway?",
+                    icon="warning"
+                )
+                if not response:
+                    return False
+
         return True
 
     # ── Run Check ─────────────────────────────────────────────────────────
@@ -893,6 +954,9 @@ class UnprotectApp(ctk.CTk):
         pw        = self._password_tab
         adv       = self._advanced_tab
         fail_fast = adv.fail_fast
+        convert_flag = adv.convert
+        # jobs value is read but not used for parallel processing in GUI
+        # (would require a redesign of the worker loop)
 
         # Resolve password once (unless wordlist mode, resolved per-file)
         password: str | None = None
@@ -919,6 +983,7 @@ class UnprotectApp(ctk.CTk):
                         output_dir=out.output_dir if out.mode == "dir" else None,
                         backup=out.backup,
                         no_overwrite=out.no_overwrite,
+                        convert=convert_flag,
                     )
                 else:
                     result = unprotect_file(
@@ -929,6 +994,7 @@ class UnprotectApp(ctk.CTk):
                         output_dir=out.output_dir if out.mode == "dir" else None,
                         backup=out.backup,
                         no_overwrite=out.no_overwrite,
+                        convert=convert_flag,
                     )
 
                 self._q.put(("row", row, result.status, result.message))
@@ -953,7 +1019,7 @@ class UnprotectApp(ctk.CTk):
                     self._q.put(("log", "Fail-fast: stopping after first error.", "warn"))
                     break
 
-        # Batch summary (mirrors CLI)
+        # Batch summary
         if total > 1:
             parts = []
             if counts["unlocked"]: parts.append(f"{counts['unlocked']} unlocked")


### PR DESCRIPTION
## What's new

### Legacy format support (`.doc`, `.xls`, `.ppt`)
- File-level decryption via `msoffcrypto-tool` now works on legacy binary Office formats
- Dedicated handlers `unprotect_doc`, `unprotect_xls`, `unprotect_ppt` added to the format registry
- A warning is emitted when a legacy file is processed without `--convert`, since XML edit locks cannot be stripped from binary formats ### `--convert` flag (requires LibreOffice)
- After decryption, legacy files are converted to their modern OpenXML equivalents (`.doc` → `.docx`, `.xls` → `.xlsx`, `.ppt` → `.pptx`) using LibreOffice in headless mode
- Conversion is handled by the new `_convert_with_libreoffice()` helper, which shells out to `libreoffice --headless --convert-to` and normalises the output path
- `--convert` is mutually exclusive with `--check` (no conversion in dry-run mode)
- Output extension is automatically updated when `--convert` is active ### `--jobs N` / `-j N` — parallel processing
- Files can now be processed concurrently using `ProcessPoolExecutor`
- Results are collected and printed in original input order regardless of completion order
- `--fail-fast` cancels pending futures when an error is encountered in parallel mode ### Enhanced PDF cleaning
- Redaction annotations (`/Subtype == /Redact`) are stripped from page annotation lists
- JavaScript actions are removed from the document `/Names` tree
- AcroForm restrictions (`/AcroForm`) are removed from the document root ### Enhanced Office cleaning
- `readOnlyRecommended` is now removed from Word `settings.xml`
- Digital signature entries (`_xmlsignatures`, `signatures.xml`) are detected and cleared across all OpenXML formats
- `--check` now detects digital signatures as a protection layer ### `unprotect_file` API — new `convert` parameter
- The public `unprotect_file()` function accepts a new `convert: bool = False` keyword argument, passed through to all format handlers

`unprotect_gui.py` : Florian van den Bersselaar and Anna Zieleman
`unprotect.py` : Hana Eun-Seo and Simon Roberge
`README.md` : Florian van den Bersselaar
`ci.yml` : Hana Eun-Seo and Anna Zieleman and Simon Roberge